### PR TITLE
Add japanase day format 

### DIFF
--- a/android/src/main/java/com/henninghall/date_picker/wheels/DayWheel.java
+++ b/android/src/main/java/com/henninghall/date_picker/wheels/DayWheel.java
@@ -100,7 +100,7 @@ public class DayWheel extends Wheel {
 
     @Override
     public String getFormatTemplate() {
-        return "yy EEE d MMM";
+        return (pickerView.locale.getLanguage() ==  "ja") ? "yy MMMd日 EEE" : "yy EEE d MMM";
     }
 
 }


### PR DESCRIPTION
Fixed the format of dates when passing ja to rocaleprops.

| japanese_ios_picker |  |
| --- | --- |
| <img width="335" alt="スクリーンショット 2019-05-08 16 44 33" src="https://user-images.githubusercontent.com/34805701/57358736-021b3b80-71b1-11e9-93be-95899ced4f35.png"> |  |
| old_android_picker | fix_android_picker |
| ![スクリーンショット 2019-05-08 16 41 30](https://user-images.githubusercontent.com/34805701/57358606-c54f4480-71b0-11e9-9842-e23786b394eb.png) | ![スクリーンショット 2019-05-08 16 45 04](https://user-images.githubusercontent.com/34805701/57358691-f16ac580-71b0-11e9-90d3-b55ffedb6913.png) |