### PR TITLE
Add Korean(ko) day format for DayWheel

### DIFF
--- a/android/src/main/java/com/henninghall/date_picker/wheels/DayWheel.java
+++ b/android/src/main/java/com/henninghall/date_picker/wheels/DayWheel.java
@@ -100,7 +100,13 @@ public class DayWheel extends Wheel {
 
     @Override
     public String getFormatTemplate() {
-        return (pickerView.locale.getLanguage() ==  "ja") ? "yy MMMd日 EEE" : "yy EEE d MMM";
+        String locale = pickerView.locale.getLanguage();
+        if(locale == "ko")
+            return "yy MMM d일 (EEE)";
+        if(locale == "ja")
+            return "yy MMMd日 EEE";
+        
+        return "yy EEE d MMM";
     }
 
 }


### PR DESCRIPTION
I added Korean day format for DayWheel.

The following improvement is minor, but will help make it easier for Koreans to use this library.

If there is the same problem in future iOS environment, I will leave the improvement as PR.