### PR TITLE
Keep "Today"-string when changing text color.

### DIFF
--- a/DatePickerIOS.js
+++ b/DatePickerIOS.js
@@ -139,6 +139,7 @@ export default class DatePickerIOS extends React.Component<Props> {
     );
     return (
       <RCTDatePickerIOS
+        key={this.props.textColor} // preventing "Today" string keep old text color when text color changes
         ref={picker => {
           this._picker = picker;
         }}

--- a/ios/RNDatePicker/DatePicker.m
+++ b/ios/RNDatePicker/DatePicker.m
@@ -64,12 +64,6 @@
     
     // Setting picker text color
     [self setValue:UIColorFromRGB(intColor) forKeyPath:@"textColor"];
-    SEL selector = NSSelectorFromString(@"setHighlightsToday:");
-    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[UIDatePicker instanceMethodSignatureForSelector:selector]];
-    BOOL no = NO;
-    [invocation setSelector:selector];
-    [invocation setArgument:&no atIndex:2];
-    [invocation invokeWithTarget:self];
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/henninghall/react-native-date-picker/issues/72