### PR TITLE
Fix Typescript compilation bug

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -84,6 +84,4 @@ interface Props extends ViewProps {
   textColor?: string
 }
 
-class DatePicker extends Component<Props> {}
-
-export default DatePicker
+export default class DatePicker extends Component<Props> {}


### PR DESCRIPTION
Thanks very much for this library -- it's great!

I was getting an error using it with Typescript:

```
node_modules/react-native-date-picker/index.d.ts:87:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

class DatePicker extends Component<Props> {}
~~~~~
```

This PR addresses the problem (at least on my machine).