### PR TITLE
highlightsToday true/false prop

### DIFF
--- a/DatePickerIOS.js
+++ b/DatePickerIOS.js
@@ -26,9 +26,10 @@ const RCTDatePickerIOS = requireNativeComponent('RNDatePicker')
  * source of truth.
  */
 export default class DatePickerIOS extends React.Component {
-  static DefaultProps = {
+  static defaultProps = {
     mode: 'datetime',
-  }
+    highlightsToday: true,
+  };
 
   // $FlowFixMe How to type a native component to be able to call setNativeProps
   _picker = null
@@ -82,6 +83,7 @@ export default class DatePickerIOS extends React.Component {
         onStartShouldSetResponder={() => true}
         onResponderTerminationRequest={() => false}
         textColor={props.textColor}
+        highlightsToday={props.highlightsToday}
       />
     )
   }

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 
-# React Native Date Picker  [![npm](https://img.shields.io/npm/v/react-native-date-picker.svg)](https://www.npmjs.com/package/react-native-date-picker) [![Build status](https://img.shields.io/bitrise/288d828c2f6731e6/master.svg?token=mGBI2QhCJBx18ffiS-MfpA&label=build)](https://app.bitrise.io/app/288d828c2f6731e6#/builds) [![npm](https://img.shields.io/npm/dm/react-native-date-picker.svg)](https://www.npmjs.com/package/react-native-date-picker) 
+# React Native Date Picker  [![npm](https://img.shields.io/npm/v/react-native-date-picker.svg)](https://www.npmjs.com/package/react-native-date-picker) [![Build status](https://img.shields.io/bitrise/288d828c2f6731e6/master.svg?token=mGBI2QhCJBx18ffiS-MfpA&label=build)](https://app.bitrise.io/app/288d828c2f6731e6#/builds) [![npm](https://img.shields.io/npm/dm/react-native-date-picker.svg)](https://www.npmjs.com/package/react-native-date-picker)
 
 
 <!--
- [![Foo](https://7pjewxutn7.execute-api.us-east-1.amazonaws.com/default/date-picker-badge)](https://app.bitrise.io/app/288d828c2f6731e6#/builds) 
+ [![Foo](https://7pjewxutn7.execute-api.us-east-1.amazonaws.com/default/date-picker-badge)](https://app.bitrise.io/app/288d828c2f6731e6#/builds)
 
- [![Foo](https://app.bitrise.io/app/288d828c2f6731e6/status.svg?token=mGBI2QhCJBx18ffiS-MfpA&branch=master)](https://app.bitrise.io/app/288d828c2f6731e6#/builds) 
+ [![Foo](https://app.bitrise.io/app/288d828c2f6731e6/status.svg?token=mGBI2QhCJBx18ffiS-MfpA&branch=master)](https://app.bitrise.io/app/288d828c2f6731e6#/builds)
  -->
 
 
-This is a React Native Date Picker with following main features: 
+This is a React Native Date Picker with following main features:
 
 📱 Supporting iOS and Android <br>
 🕑 3 different modes: Time, Date, DateTime <br>
 🌍 Multiple languages<br>
 🎨 Customizable<br>
-<!-- 
+<!--
 [![Monthly download](https://img.shields.io/npm/dm/react-native-date-picker.svg)](https://img.shields.io/npm/dm/react-native-date-picker.svg)
 [![Total downloads](https://img.shields.io/npm/dt/react-native-date-picker.svg)](https://img.shields.io/npm/dt/react-native-date- picker.svg) -->
 
@@ -25,21 +25,21 @@ This is a React Native Date Picker with following main features:
 <table>
   <tr>
     <td align="center"><b>iOS</b></td>
-    <td align="center"><b>Android</b></td>  
+    <td align="center"><b>Android</b></td>
   </tr>
    <tr>
     <td><img src="docs/react-native-date-picker.gif" alt="React Native Date Picker" title="React Native Date Picker" height="150px" />
     </td>
     <td><img src="docs/react-native-date-picker-android.gif" alt="React Native Date Picker Android" height="150px" style="margin-left:10px" />
-    </td>  
+    </td>
   </tr>
       <tr>
     <td align="center">A slightly improved DatePickerIOS.</td>
-    <td align="center">A custom made native component.</td>  
+    <td align="center">A custom made native component.</td>
   </tr>
-  
+
   </table>
-  
+
 ## Installation
 
 1. `npm install react-native-date-picker --save`
@@ -78,28 +78,29 @@ mode | The date picker mode. {'datetime', 'date', 'time'} | <img src="docs/datet
 locale | The locale for the date picker. Changes language, date order and am/pm preferences. Value needs to be a <a title="react native datepicker locale id" href="https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html">Locale ID.</a>| <img src="docs/locale-ios.png" alt="React Native Date picker locale language ios" height="120px" />|<img src="docs/locale-android.png" alt="React Native Date picker locale language android" height="120px" />
 textColor | Changes the text color. | <img src="docs/colors-ios.png" alt="react native datepicker text color background color ios" height="120px" />|<img src="docs/colors-android.png" alt="Text color background color android" height="120px" />
 timeZoneOffsetInMinutes | Timezone offset in minutes (default: device's timezone)
-  
+highlightsToday | Whether or not to display "Today" in place of today's date (default: true)
+
 
 ## About
-📅 &nbsp; React Native Date Picker is a cross platform component working on both iOS and Android. It uses the slightly improved DatePickerIOS on iOS and a custom picker on Android which has similar look and feel. The datetime mode might be particulary interesting if you looking for a way to avoid two different popup pickers on android. 
+📅 &nbsp; React Native Date Picker is a cross platform component working on both iOS and Android. It uses the slightly improved DatePickerIOS on iOS and a custom picker on Android which has similar look and feel. The datetime mode might be particulary interesting if you looking for a way to avoid two different popup pickers on android.
 
 ## FAQ
 
 ### Can I use expo?
-Unfortunately, expo does not support this date picker at the moment. Upvote <a href="https://expo.canny.io/feature-requests/p/support-react-native-date-picker">this feature request</a> if you would like to have it included. 
+Unfortunately, expo does not support this date picker at the moment. Upvote <a href="https://expo.canny.io/feature-requests/p/support-react-native-date-picker">this feature request</a> if you would like to have it included.
 
 
 ### How do i change the date order? (To YYYY-MM-DD etc)
 The order is determined by the `locale` prop. Set for instance `locale='fr'`to get the France preference.
 
 ### How do i change the 12/24h or AM/PM format?
-On iOS the 12/24h preference is determined by the `locale` prop. Set for instance `locale='fr'`to get the France preference. On Android the 12/24h format is determined by the device setting. When using 12h mode the AM/PM part of the picker will be displayed. 
+On iOS the 12/24h preference is determined by the `locale` prop. Set for instance `locale='fr'`to get the France preference. On Android the 12/24h format is determined by the device setting. When using 12h mode the AM/PM part of the picker will be displayed.
 
 ### Is it possible to show only month and year?
 This is unfortunately not possible due to the limitation in DatePickerIOS. You should be able to create your own month-year picker with for instance https://github.com/TronNatthakorn/react-native-wheel-pick.
 
 ### Why does the Android app crash in production?
-If you have enabled <a href="https://facebook.github.io/react-native/docs/signed-apk-android#enabling-proguard-to-reduce-the-size-of-the-apk-optional">Proguard</a> for Android you might need to ignore some classes to get the the picker to work propery in android production/release mode. Add these lines to you proguard file (often called `proguard-rules.pro`): 
+If you have enabled <a href="https://facebook.github.io/react-native/docs/signed-apk-android#enabling-proguard-to-reduce-the-size-of-the-apk-optional">Proguard</a> for Android you might need to ignore some classes to get the the picker to work propery in android production/release mode. Add these lines to you proguard file (often called `proguard-rules.pro`):
 ```
 -keep public class net.time4j.android.ApplicationStarter
 -keep public class net.time4j.PrettyTime
@@ -109,9 +110,9 @@ If you have enabled <a href="https://facebook.github.io/react-native/docs/signed
 - [x] Mode: datetime
 - [x] Mode: date
 - [x] Mode: time
-- [x] Locale support. (AM/PM, 12h/24h toggled and strings translated) 
+- [x] Locale support. (AM/PM, 12h/24h toggled and strings translated)
 - [x] Replace todays date with the string "Today" (considering locale)
-- [x] Animate to date when state change occur. 
+- [x] Animate to date when state change occur.
 - [x] Switch between AM/PM when scrolling between forenoon and afternoon.
 - [x] Support maximumDate/minimumDate.
 - [x] Minute interval prop.
@@ -121,7 +122,7 @@ If you have enabled <a href="https://facebook.github.io/react-native/docs/signed
 ## Why another React Native date picker?
 One of the strongest reason to use react native is its cross platform compatibility. Most of the official components are working seamlessly on both platforms but there are some with single platform support only. The react native datepicker is one example where both <a href="https://facebook.github.io/react-native/docs/datepickerios">DatePickerIOS</a> and <a href="https://facebook.github.io/react-native/docs/datepickerandroid">DatePickerAndroid</a> are present. The reason for this is that the default date picker is implemented in seperate ways, iOS normally have an integrated view picker wheel where android has different pickers in a dialog format.
 
-If you want to use these pickers you can combile the official ones or a third party module that already done that for you. If you on the other hand want have a more unified design between your android and ios app, this module is for you. The datetime mode can be particularly helpful to avoid 2 separate picker dialogs on android. 
+If you want to use these pickers you can combile the official ones or a third party module that already done that for you. If you on the other hand want have a more unified design between your android and ios app, this module is for you. The datetime mode can be particularly helpful to avoid 2 separate picker dialogs on android.
 
 
 
@@ -129,6 +130,6 @@ If you want to use these pickers you can combile the official ones or a third pa
 ## TODO EXTRA
 - [ ] Transparent background support. (Probably need to include transparent gradient).
 - [ ] Screen recordings
-- [ ] Gray out max/min values. 
+- [ ] Gray out max/min values.
 - [ ] Align text to right.
 -->

--- a/ios/RNDatePicker/DatePicker.h
+++ b/ios/RNDatePicker/DatePicker.h
@@ -10,6 +10,7 @@
 @interface DatePicker : UIDatePicker
 
 - (void)setTextColorProp:(NSString *)hexColor;
+- (void)setHighlightsTodayProp:(BOOL)highlightsToday;
 
 @end
 

--- a/ios/RNDatePicker/DatePicker.m
+++ b/ios/RNDatePicker/DatePicker.m
@@ -64,9 +64,14 @@
 
     // Setting picker text color
     [self setValue:UIColorFromRGB(intColor) forKeyPath:@"textColor"];
-    [self performSelector:@selector(setHighlightsToday:) withObject:NO];
 }
 
+- (void)setHighlightsTodayProp:(BOOL)highlightsToday
+{
+    if (highlightsToday == NO) {
+        [self performSelector:@selector(setHighlightsToday:) withObject:NO];
+    }
+}
 
 RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 

--- a/ios/RNDatePicker/DatePicker.m
+++ b/ios/RNDatePicker/DatePicker.m
@@ -33,15 +33,15 @@
     if([cleanString length] == 6) {
         cleanString = [cleanString stringByAppendingString:@"ff"];
     }
-    
+
     unsigned int baseValue;
     [[NSScanner scannerWithString:cleanString] scanHexInt:&baseValue];
-    
+
     float red = ((baseValue >> 24) & 0xFF)/255.0f;
     float green = ((baseValue >> 16) & 0xFF)/255.0f;
     float blue = ((baseValue >> 8) & 0xFF)/255.0f;
     float alpha = ((baseValue >> 0) & 0xFF)/255.0f;
-    
+
     return [UIColor colorWithRed:red green:green blue:blue alpha:alpha];
 }
 
@@ -61,9 +61,10 @@
     NSScanner *scanner = [NSScanner scannerWithString:hexColor];
     [scanner setScanLocation:1]; // bypass '#' character
     [scanner scanHexInt:&intColor];
-    
+
     // Setting picker text color
     [self setValue:UIColorFromRGB(intColor) forKeyPath:@"textColor"];
+    [self performSelector:@selector(setHighlightsToday:) withObject:NO];
 }
 
 

--- a/ios/RNDatePicker/RNDatePickerManager.m
+++ b/ios/RNDatePicker/RNDatePickerManager.m
@@ -39,11 +39,13 @@ RCT_EXPORT_VIEW_PROPERTY(minuteInterval, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_REMAP_VIEW_PROPERTY(mode, datePickerMode, UIDatePickerMode)
 RCT_REMAP_VIEW_PROPERTY(timeZoneOffsetInMinutes, timeZone, NSTimeZone)
-
-
 RCT_CUSTOM_VIEW_PROPERTY(textColor, NSString, DatePicker)
 {
     [view setTextColorProp:[RCTConvert NSString:json]];
+}
+RCT_CUSTOM_VIEW_PROPERTY(highlightsToday, BOOL, DatePicker)
+{
+    [view setHighlightsTodayProp:[RCTConvert BOOL:json]];
 }
 
 @end


### PR DESCRIPTION
Fixes #119 prevents date picker using today highlight color when setting mode to date/datetime with textColor also set.

~~As you can see it's appears to be fixed now!~~

UPDATE: Changing this pull request to add a prop instead, `highlightsToday` named in accordance with the iOS RNDatePicker property of the same name that controls whether or not to highlight Today's date in the picker with a different text color and changing the date string for that option to "Today".

With `mode="date"`, `textColor="#FFFFFF"` and `highlightsToday={false}`.

![image](https://user-images.githubusercontent.com/8391902/67255811-ada21900-f4cf-11e9-90a1-231aecee21a3.png)

With `mode="datetime"`,`textColor="#FFFFFF"` and `highlightsToday={false}`.

![image](https://user-images.githubusercontent.com/8391902/67255758-66b42380-f4cf-11e9-8f21-4bbc2935faf4.png)