### PR TITLE
Suppress "DatePickerIOS has been merged..." warning

### DIFF
--- a/DatePickerAndroid.js
+++ b/DatePickerAndroid.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { DatePickerIOS, requireNativeComponent, StyleSheet } from 'react-native'
+import { StyleSheet, requireNativeComponent } from 'react-native'
 import moment from 'moment'
 import { throwIfInvalidProps } from './propChecker'
 
@@ -70,7 +70,5 @@ const styles = StyleSheet.create({
     height: 180,
   },
 })
-
-DatePickerAndroid.propTypes = DatePickerIOS.propTypes
 
 export default DatePickerAndroid


### PR DESCRIPTION
Fixes #112.

Had a look into the code for `DatePickerIOS` as of the [latest commit](https://github.com/facebook/react-native/blob/c10c147bccd001dcff152fb5c8ea9fd7f590c868/Libraries/Components/DatePicker/DatePickerIOS.ios.js) to `react-native` and it doesn't seem that `DatePickerIOS.ios.js` even defined `propTypes` in the first place for `DatePickerAndroid.propTypes = DatePickerIOS.propTypes` to even use usefully.

It just comes out as setting `DatePickerAndroid.propTypes = undefined`.

So simple fix it seems is to simply remove that line and remove the import of `DatePickerIOS` from `react-native` in `DatePickerAndroid.js` for this package, as the [deprecation warning is raised by a getter for the exported component](https://github.com/facebook/react-native/blob/21f1cce148b64d9b261e9d95d18ba685f6963a4d/index.js#L128) from `react-native`.