### PR TITLE
Add suggestion to try other library for non-date wheel picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ On iOS the 12/24h preference is determined by the `locale` prop. Set for instanc
 
 This is unfortunately not possible due to the limitation in DatePickerIOS. You should be able to create your own month-year picker with for instance https://github.com/TronNatthakorn/react-native-wheel-pick.
 
+### Can I show non-date related data inside the picker?
+
+No, unfortunately this package only supports picking dates and times. If you need to render other types of list items inside a wheel picker, checkout <a href="https://github.com/adammcarth/react-native-segmented-picker">react-native-segmented-picker</a>.
+
 ### Why does the Android app crash in production?
 
 If you have enabled <a href="https://facebook.github.io/react-native/docs/signed-apk-android#enabling-proguard-to-reduce-the-size-of-the-apk-optional">Proguard</a> for Android you might need to ignore some classes to get the the picker to work propery in android production/release mode. Add these lines to you proguard file (often called `proguard-rules.pro`):


### PR DESCRIPTION
Hi @henninghall,

Thanks again for all your hard work on this library - I've used this in production on a number of different projects now.

Happy to have this pull request turned down (PSA - I am the author of the library), but one thing I've always struggled with is finding a library that does the "wheel spinner" picklist style in multiple columns for data that isn't to do with dates and times. I actually first found `react-native-date-picker` while trying to find a package that let me render a multi dimensional list, but it was a shame to find out you couldn't customise it to render different kinds of data.

In light of that, I ended up creating my own package for this called [`react-native-segmented-picker`](https://github.com/adammcarth/react-native-segmented-picker). I did think about extending your package to do this, but the more I thought about it - they seemed like two seperate domains.

This pull request simply adds an FAQ to point to the package if people are trying to show other kinds of lists inside a wheel picker. If you think this is something other people would find useful, feel free to merge it in.

Cheers,

Adam.