### PR TITLE
Bugfix: onDateChange not called for some locales

### DIFF
--- a/android/src/main/java/com/henninghall/date_picker/PickerView.java
+++ b/android/src/main/java/com/henninghall/date_picker/PickerView.java
@@ -155,7 +155,7 @@ public class PickerView extends RelativeLayout {
         return dateTemplate + " "
                 + hourWheel.getFormatTemplate() + " "
                 + minutesWheel.getFormatTemplate()
-                +  ampmWheel.getFormatTemplate();
+                + ampmWheel.getFormatTemplate();
     }
 
     public String getDateString() {

--- a/android/src/main/java/com/henninghall/date_picker/WheelChangeListenerImpl.java
+++ b/android/src/main/java/com/henninghall/date_picker/WheelChangeListenerImpl.java
@@ -30,7 +30,8 @@ public class WheelChangeListenerImpl implements WheelChangeListener {
         try {
             dateFormat.setTimeZone(timeZone);
             Calendar date = Calendar.getInstance(timeZone);
-            date.setTime(dateFormat.parse(this.pickerView.getDateString()));
+            String toParse = this.pickerView.getDateString();
+            date.setTime(dateFormat.parse(toParse));
 
             if (minDate != null && date.before(minDate)) pickerView.applyOnVisibleWheels(
                     new AnimateToDate(minDate)

--- a/android/src/main/java/com/henninghall/date_picker/wheels/AmPmWheel.java
+++ b/android/src/main/java/com/henninghall/date_picker/wheels/AmPmWheel.java
@@ -41,8 +41,13 @@ public class AmPmWheel extends Wheel {
     }
 
     @Override
-    public String getFormatTemplate() {
+    public String getDisplayFormatTemplate() {
         return Settings.usesAmPm() ? " a " : "";
+    }
+
+    @Override
+    public String getFormatTemplate() {
+        return  " a ";
     }
 
     @Override

--- a/android/src/main/java/com/henninghall/date_picker/wheels/DateWheel.java
+++ b/android/src/main/java/com/henninghall/date_picker/wheels/DateWheel.java
@@ -34,6 +34,11 @@ public class DateWheel extends Wheel
     }
 
     @Override
+    public String getDisplayFormatTemplate() {
+        return "d";
+    }
+
+    @Override
     public String getFormatTemplate() {
         return "d";
     }

--- a/android/src/main/java/com/henninghall/date_picker/wheels/DayWheel.java
+++ b/android/src/main/java/com/henninghall/date_picker/wheels/DayWheel.java
@@ -111,7 +111,7 @@ public class DayWheel extends Wheel {
     }
 
     @Override
-    public String getFormatTemplate() {
+    public String getDisplayFormatTemplate() {
         String locale = pickerView.locale.getLanguage();
         if(locale.equals("ko"))
             return "yy MMM d일 (EEE)";
@@ -121,6 +121,11 @@ public class DayWheel extends Wheel {
             return "yy EEE MMM d";
         }
         else return "yy EEE d MMM";
+    }
+
+    @Override
+    public String getFormatTemplate() {
+        return "yy EEE MMM d";
     }
 
     @Override

--- a/android/src/main/java/com/henninghall/date_picker/wheels/HourWheel.java
+++ b/android/src/main/java/com/henninghall/date_picker/wheels/HourWheel.java
@@ -20,7 +20,7 @@ public class HourWheel extends Wheel {
 
         for(int i=0; i<numberOfHours; i++) {
             values.add(format.format(cal.getTime()));
-            displayValues.add(format.format(cal.getTime()));
+            displayValues.add(displayFormat.format(cal.getTime()));
             cal.add(Calendar.HOUR_OF_DAY, 1);
         }
         picker.setDisplayedValues(values.toArray(new String[0]),true);
@@ -34,8 +34,13 @@ public class HourWheel extends Wheel {
     }
 
     @Override
-    public String getFormatTemplate() {
+    public String getDisplayFormatTemplate() {
         return Settings.usesAmPm() ? "h": "HH";
+    }
+
+    @Override
+    public String getFormatTemplate() {
+        return "h";
     }
 
     @Override

--- a/android/src/main/java/com/henninghall/date_picker/wheels/MinutesWheel.java
+++ b/android/src/main/java/com/henninghall/date_picker/wheels/MinutesWheel.java
@@ -36,6 +36,11 @@ public class MinutesWheel extends Wheel {
     }
 
     @Override
+    public String getDisplayFormatTemplate() {
+        return "mm";
+    }
+
+    @Override
     public String getFormatTemplate() {
         return "mm";
     }

--- a/android/src/main/java/com/henninghall/date_picker/wheels/MonthWheel.java
+++ b/android/src/main/java/com/henninghall/date_picker/wheels/MonthWheel.java
@@ -33,6 +33,11 @@ public class MonthWheel extends Wheel
     }
 
     @Override
+    public String getDisplayFormatTemplate() {
+        return "LLLL";
+    }
+
+    @Override
     public String getFormatTemplate() {
         return "LLLL";
     }
@@ -55,6 +60,6 @@ public class MonthWheel extends Wheel
     }
 
     private SimpleDateFormat getFormat(Locale locale) {
-        return new SimpleDateFormat(this.getFormatTemplate(), locale);
+        return new SimpleDateFormat(this.getDisplayFormatTemplate(), locale);
     }
 }

--- a/android/src/main/java/com/henninghall/date_picker/wheels/Wheel.java
+++ b/android/src/main/java/com/henninghall/date_picker/wheels/Wheel.java
@@ -20,6 +20,7 @@ public abstract class Wheel {
     abstract void init();
     public abstract boolean visible();
     public abstract Paint.Align getTextAlign();
+    public abstract String getDisplayFormatTemplate();
     public abstract String getFormatTemplate();
 
     ArrayList<String> values;
@@ -44,7 +45,7 @@ public abstract class Wheel {
     }
 
     private void clearValues(){
-        this.displayFormat = new SimpleDateFormat(getFormatTemplate(), pickerView.locale);
+        this.displayFormat = new SimpleDateFormat(getDisplayFormatTemplate(), pickerView.locale);
         this.format = new SimpleDateFormat(getFormatTemplate(), LocaleUtils.toLocale("en_US"));
         this.values = new ArrayList<>();
         this.displayValues= new ArrayList<>();

--- a/android/src/main/java/com/henninghall/date_picker/wheels/YearWheel.java
+++ b/android/src/main/java/com/henninghall/date_picker/wheels/YearWheel.java
@@ -60,9 +60,15 @@ public class YearWheel extends Wheel
     }
 
     @Override
+    public String getDisplayFormatTemplate() {
+        return "y";
+    }
+
+    @Override
     public String getFormatTemplate() {
         return "y";
     }
+
 
 }
 

--- a/examples/advanced/package.json
+++ b/examples/advanced/package.json
@@ -1,28 +1,28 @@
 {
-    "name": "rn602",
-    "version": "0.0.1",
-    "private": true,
-    "scripts": {
-        "start": "react-native start",
-        "test": "jest",
-        "lint": "eslint ."
-    },
-    "dependencies": {
-        "react": "16.8.6",
-        "react-native": "0.60.3",
-        "react-native-date-picker": "^2.6.1"
-    },
-    "devDependencies": {
-        "@babel/core": "^7.5.4",
-        "@babel/runtime": "^7.5.4",
-        "@react-native-community/eslint-config": "^0.0.5",
-        "babel-jest": "^24.8.0",
-        "eslint": "^6.0.1",
-        "jest": "^24.8.0",
-        "metro-react-native-babel-preset": "^0.55.0",
-        "react-test-renderer": "16.8.6"
-    },
-    "jest": {
-        "preset": "react-native"
-    }
+  "name": "rn602",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "react-native start",
+    "test": "jest",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "react": "16.8.6",
+    "react-native": "0.60.3",
+    "react-native-date-picker": "../../"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.5.4",
+    "@babel/runtime": "^7.5.4",
+    "@react-native-community/eslint-config": "^0.0.5",
+    "babel-jest": "^24.8.0",
+    "eslint": "^6.0.1",
+    "jest": "^24.8.0",
+    "metro-react-native-babel-preset": "^0.55.0",
+    "react-test-renderer": "16.8.6"
+  },
+  "jest": {
+    "preset": "react-native"
+  }
 }

--- a/examples/advanced/yarn.lock
+++ b/examples/advanced/yarn.lock
@@ -5132,10 +5132,8 @@ react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react-native-date-picker@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/react-native-date-picker/-/react-native-date-picker-2.6.1.tgz#ad322cc12a760ad7a2cabce18928652dd4f8b8f0"
-  integrity sha512-9FVOMulMs5mWfjWcoEuHotIh5LiJPHvrSUEsHfiYW48kME3GF/nE0DyNg4qDuJFRsZr8mIdiNyLQHQbnhGKZ/Q==
+react-native-date-picker@../../:
+  version "2.7.3"
   dependencies:
     moment "^2.22.1"
 


### PR DESCRIPTION
Fixes an bug that was introduced in 2.7.0 by separating display format and value format properly.

Fixes https://github.com/henninghall/react-native-date-picker/issues/111