### PR TITLE
Fixing different language related crashes

### DIFF
--- a/android/src/main/java/com/henninghall/date_picker/DayFormats.java
+++ b/android/src/main/java/com/henninghall/date_picker/DayFormats.java
@@ -736,6 +736,15 @@ public class DayFormats {
         put("zh_HK","M月d日EEE");
         put("zh_MO","M月d日EEE");
         put("zh_SG","M月d日EEE");
+        put("zh_Hans","M月d日EEE");
+        put("zh_Hans_CN","M月d日EEE");
+        put("zh_Hans_HK","M月d日EEE");
+        put("zh_Hans_MO","M月d日EEE");
+        put("zh_Hans_SG","M月d日EEE");
+        put("zh_Hant", "M月d日EEE");
+        put("zh_Hant_HK","M月d日EEE");
+        put("zh_Hant_MO","M月d日EEE");
+        put("zh_Hant_TW","M月d日EEE");
         put("zu","EEE MMM d");
         put("zu_ZA","EEE MMM d");
     }};

--- a/android/src/main/java/com/henninghall/date_picker/LocaleUtils.java
+++ b/android/src/main/java/com/henninghall/date_picker/LocaleUtils.java
@@ -1,12 +1,8 @@
 package com.henninghall.date_picker;
 
-import android.os.Build;
-import android.util.Log;
-
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Locale;
 
 public class LocaleUtils {
@@ -36,6 +32,18 @@ public class LocaleUtils {
     static String getDateTimePattern(Locale locale){
         DateFormat format = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL, locale);
         return ((SimpleDateFormat)format).toLocalizedPattern().replace(",", "");
+    }
+
+     public static Locale getLocale(String languageTag){
+        Locale locale;
+        try{
+            locale = org.apache.commons.lang3.LocaleUtils.toLocale(languageTag);
+        } catch (Exception e ){
+            // Some locales can only be interpreted from country string (for instance zh_Hans_CN )
+            String firstPartOfLanguageTag = languageTag.substring(0, languageTag.indexOf(""));
+            locale = org.apache.commons.lang3.LocaleUtils.toLocale(firstPartOfLanguageTag);
+        }
+        return locale;
     }
 
 }

--- a/android/src/main/java/com/henninghall/date_picker/props/LocaleProp.java
+++ b/android/src/main/java/com/henninghall/date_picker/props/LocaleProp.java
@@ -3,8 +3,8 @@ package com.henninghall.date_picker.props;
 import android.os.Build;
 
 import com.facebook.react.bridge.Dynamic;
+import com.henninghall.date_picker.LocaleUtils;
 
-import org.apache.commons.lang3.LocaleUtils;
 
 import java.util.Locale;
 
@@ -18,7 +18,7 @@ public class LocaleProp extends Prop<Locale> {
     }
 
     static private Locale getDefaultLocale(){
-        return LocaleUtils.toLocale(getDefaultLanguageTag());
+        return LocaleUtils.getLocale(getDefaultLanguageTag());
     }
 
     static private String getDefaultLanguageTag(){
@@ -34,7 +34,7 @@ public class LocaleProp extends Prop<Locale> {
     @Override
     public Locale toValue(Dynamic value){
         this.languageTag = value.asString().replace('-','_');
-        return LocaleUtils.toLocale(languageTag);
+        return LocaleUtils.getLocale(languageTag);
     }
 
 }


### PR DESCRIPTION
- Add missing Chinese locales. Fixes https://github.com/henninghall/react-native-date-picker/issues/170 
- Prevent crash related to parsing of default locales. Fixes https://github.com/henninghall/react-native-date-picker/issues/169 

