### PR TITLE
fix  bug when language is Chinese or Japanese in Android

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,6 +1,6 @@
 name: "Android: build & test"
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build_and_test:

--- a/android/src/main/java/com/henninghall/date_picker/LocaleUtils.java
+++ b/android/src/main/java/com/henninghall/date_picker/LocaleUtils.java
@@ -26,7 +26,10 @@ public class LocaleUtils {
 
     public static String getDatePattern(Locale locale){
         DateFormat df = DateFormat.getDateInstance(DateFormat.FULL, locale);
-        return ((SimpleDateFormat)df).toLocalizedPattern().replace(",", "");
+        return ((SimpleDateFormat) df).toLocalizedPattern()
+                .replaceAll(",", "")
+                .replaceAll("([a-zA-Z]+)", " $1")
+                .trim();
     }
 
     static String getDateTimePattern(Locale locale){

--- a/android/src/main/java/com/henninghall/date_picker/Utils.java
+++ b/android/src/main/java/com/henninghall/date_picker/Utils.java
@@ -62,7 +62,7 @@ public class Utils {
     }
 
     public static ArrayList<String> splitOnSpace(String value){
-        String[] array = value.split(" ");
+        String[] array = value.split("\\s+");
         ArrayList<String> arrayList = new ArrayList<>();
         Collections.addAll(arrayList, array);
         return arrayList;

--- a/examples/detox/e2e/tests/displayText.spec.js
+++ b/examples/detox/e2e/tests/displayText.spec.js
@@ -69,7 +69,7 @@ describe('Display text', () => {
     })
 
     it('zh-CH', async () => {
-      await expectLocaleDateString('zh-CH', '2001年' + '1月' + '1日')
+      await expectLocaleDateString('zh-CH', '2001年' + '一月' + '1日')
     })
   })
 

--- a/examples/detox/e2e/tests/displayText.spec.js
+++ b/examples/detox/e2e/tests/displayText.spec.js
@@ -1,4 +1,11 @@
-const { setLocale, expectDateString, scrollWheel } = require('../utils')
+const {
+  setMode,
+  setLocale,
+  expectDateString,
+  scrollWheel,
+  setMinimumDate,
+  setMaximumDate,
+} = require('../utils')
 
 describe('Display text', () => {
   before(async () => {
@@ -29,6 +36,40 @@ describe('Display text', () => {
 
     it('zh-CH', async () => {
       await expectLocaleDateString('zh-CH', '1月2日周日 上午 1200')
+    })
+  })
+
+  describe('date', () => {
+    before(async () => {
+      await device.reloadReactNative()
+      await element(by.text('Advanced')).tap()
+      await setMinimumDate(undefined)
+      await setMaximumDate(undefined)
+      await setMode('date')
+    })
+
+    it('en-US', async () => {
+      await expectLocaleDateString('en-US', 'February' + '1' + '2000')
+    })
+
+    it('pt-BR', async () => {
+      await expectLocaleDateString('pt-BR', '2janeiro' + '2000')
+    })
+
+    it('sv-SE', async () => {
+      await expectLocaleDateString('sv-SE', '2' + 'januari' + '2000')
+    })
+
+    it('ko', async () => {
+      await expectLocaleDateString('ko', '2001년' + '1월' + '1일')
+    })
+
+    it('ja', async () => {
+      await expectLocaleDateString('ja', '2001年' + '1月' + '1日')
+    })
+
+    it('zh-CH', async () => {
+      await expectLocaleDateString('zh-CH', '2001年' + '1月' + '1日')
     })
   })
 


### PR DESCRIPTION
When language is Chinese or Japanese in Android and mode is 'date', the method 'getDatePattern' return a string without space, so the picker show wrong data.