### PR TITLE
Fix return of wrong pattern piece

### DIFF
--- a/android/src/main/java/com/henninghall/date_picker/LocaleUtils.java
+++ b/android/src/main/java/com/henninghall/date_picker/LocaleUtils.java
@@ -17,7 +17,7 @@ public class LocaleUtils {
     */
     public static String getPatternIncluding(String format, Locale locale) {
         for (String piece: getFullPatternPieces(locale)){
-            if(piece.contains(format)) {
+            if(piece.contains(format) && !piece.contains("'")) {
                 return piece;
             }
         }
@@ -50,5 +50,3 @@ public class LocaleUtils {
     }
 
 }
-
-


### PR DESCRIPTION
The getPatternIncluding method would return quoted pieces if the contents of the quoted part included the format letter.

For instance for Danish (da_DK), the pattern is `"EEE 'den' d. MMM"`. If we are calling `getPatternIncluding("d", "da_DK")`, the method would return `"den'"`, but we would actually like to return `"d."`.

This commit ignores pieces with apostrophe (`'`) in them.

Fixes #194 

This might also handle #185, I'm not sure.

On a sidenote, I also think `getFullPatternPieces` is buggy (because of `getDatePattern`). I'd expect `getFullPatternPieces("da_DK")` to return this list: `["EEE", "'den'", "d.", "MMM"]`. Instead, it returns `["EEE", "'", "den'", "d.", "MMM"]`. It's the regex in `getDatePattern` that doesn't handle apostrophes (this line: `.replaceAll("([a-zA-Z]+)", " $1")`). I'm not sure what this extra space before letters is needed for?