### PR TITLE
Support dateFormat property for android

### DIFF
--- a/android/src/main/java/com/henninghall/date_picker/DatePickerManager.java
+++ b/android/src/main/java/com/henninghall/date_picker/DatePickerManager.java
@@ -9,6 +9,7 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactPropGroup;
 import com.henninghall.date_picker.props.DateProp;
 import com.henninghall.date_picker.props.FadeToColorProp;
+import com.henninghall.date_picker.props.DateFormatProp;
 import com.henninghall.date_picker.props.LocaleProp;
 import com.henninghall.date_picker.props.MaximumDateProp;
 import com.henninghall.date_picker.props.MinimumDateProp;
@@ -40,7 +41,7 @@ public class DatePickerManager extends SimpleViewManager<PickerView>  {
     return new PickerView();
   }
 
-  @ReactPropGroup(names = { DateProp.name, ModeProp.name, LocaleProp.name, MaximumDateProp.name,
+  @ReactPropGroup(names = { DateProp.name, DateFormatProp.name, ModeProp.name, LocaleProp.name, MaximumDateProp.name,
           MinimumDateProp.name, FadeToColorProp.name, TextColorProp.name, UtcProp.name, MinuteIntervalProp.name})
   public void setProps(PickerView view, int index, Dynamic value) {
     updateProp("setProps", view, index, value);

--- a/android/src/main/java/com/henninghall/date_picker/State.java
+++ b/android/src/main/java/com/henninghall/date_picker/State.java
@@ -26,7 +26,7 @@ public class State {
     private final Prop modeProp = new ModeProp();
     private final LocaleProp localeProp = new LocaleProp();
     private final FadeToColorProp fadeToColorProp = new FadeToColorProp();
-    private final DateFormatProp dateFormat = new DateFormatProp();
+    private final DateFormatProp dateFormatProp = new DateFormatProp();
     private final TextColorProp textColorProp = new TextColorProp();
     private final MinuteIntervalProp minuteIntervalProp = new MinuteIntervalProp();
     private final MinimumDateProp minimumDateProp = new MinimumDateProp();

--- a/android/src/main/java/com/henninghall/date_picker/State.java
+++ b/android/src/main/java/com/henninghall/date_picker/State.java
@@ -39,7 +39,7 @@ public class State {
         put(ModeProp.name, modeProp);
         put(LocaleProp.name, localeProp);
         put(FadeToColorProp.name, fadeToColorProp);
-        put(DateFormatProp.name, dateFormatProp)
+        put(DateFormatProp.name, dateFormatProp);
         put(TextColorProp.name, textColorProp);
         put(MinuteIntervalProp.name, minuteIntervalProp);
         put(MinimumDateProp.name, minimumDateProp);

--- a/android/src/main/java/com/henninghall/date_picker/State.java
+++ b/android/src/main/java/com/henninghall/date_picker/State.java
@@ -4,6 +4,7 @@ import com.facebook.react.bridge.Dynamic;
 import com.henninghall.date_picker.models.Mode;
 import com.henninghall.date_picker.props.DateProp;
 import com.henninghall.date_picker.props.FadeToColorProp;
+import com.henninghall.date_picker.props.DateFormatProp;
 import com.henninghall.date_picker.props.HeightProp;
 import com.henninghall.date_picker.props.LocaleProp;
 import com.henninghall.date_picker.props.MaximumDateProp;
@@ -25,6 +26,7 @@ public class State {
     private final Prop modeProp = new ModeProp();
     private final LocaleProp localeProp = new LocaleProp();
     private final FadeToColorProp fadeToColorProp = new FadeToColorProp();
+    private final DateFormatProp dateFormat = new DateFormatProp();
     private final TextColorProp textColorProp = new TextColorProp();
     private final MinuteIntervalProp minuteIntervalProp = new MinuteIntervalProp();
     private final MinimumDateProp minimumDateProp = new MinimumDateProp();
@@ -37,6 +39,7 @@ public class State {
         put(ModeProp.name, modeProp);
         put(LocaleProp.name, localeProp);
         put(FadeToColorProp.name, fadeToColorProp);
+        put(DateFormatProp.name, dateFormatProp)
         put(TextColorProp.name, textColorProp);
         put(MinuteIntervalProp.name, minuteIntervalProp);
         put(MinimumDateProp.name, minimumDateProp);
@@ -64,6 +67,10 @@ public class State {
 
     public String getFadeToColor() {
         return (String) fadeToColorProp.getValue();
+    }
+
+    public String getDateFormat() {
+        return (String) dateFormatProp.getValue();
     }
 
     public String getTextColor() {

--- a/android/src/main/java/com/henninghall/date_picker/props/DateFormatProp.java
+++ b/android/src/main/java/com/henninghall/date_picker/props/DateFormatProp.java
@@ -1,0 +1,13 @@
+package com.henninghall.date_picker.props;
+
+import com.facebook.react.bridge.Dynamic;
+
+public class DateFormatProp extends Prop<String> {
+    public static final String name = "dateFormat";
+    
+    @Override
+    public String toValue(Dynamic value){
+        return value.asString();
+    }
+
+}

--- a/android/src/main/java/com/henninghall/date_picker/wheels/DayWheel.java
+++ b/android/src/main/java/com/henninghall/date_picker/wheels/DayWheel.java
@@ -101,6 +101,9 @@ public class DayWheel extends Wheel {
     }
 
     private String getDisplayValueFormatPattern(){
+        if (state.getDateFormat() != null && state.getDateFormat() != "") {
+            return state.getDateFormat();
+        }
         return DayFormats.get(state.getLocaleLanguageTag());
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,6 +60,11 @@ export interface DatePickerProps extends ViewProps {
   fadeToColor?: string
 
   /**
+   * Custom date format for android
+   */
+  dateFormat?: string
+
+  /**
    * Changes the text color.
    */
   textColor?: string

--- a/propTypes.js
+++ b/propTypes.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 const androidProptypes = {
   fadeToColor: PropTypes.string,
+  dateFormat: PropsTypes.string,
 }
 
 const DateType = PropTypes.instanceOf(Date)

--- a/propTypes.js
+++ b/propTypes.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 const androidProptypes = {
   fadeToColor: PropTypes.string,
-  dateFormat: PropsTypes.string,
+  dateFormat: PropTypes.string,
 }
 
 const DateType = PropTypes.instanceOf(Date)


### PR DESCRIPTION
Currently we are using `'react-native-date-picker'` in our app. It works great for most of the cases. Excepts in android narrow screen, it doesn't display Finnish weekdays nicely. For other languages, such as English, the date picker show short form of week days and there is no problem.

This PR will support for custom date format for `DayWheel` instead of always getting the format from the locale (in `DayFormats.java`).

This PR might need further modification and improvements, any suggestion for fixing the issue with Finnish locale in small screen is welcome. Thank you!
 
| 1        | 2           | 
| ------------- |:-------------:|
| ![Screenshot_1594035656](https://user-images.githubusercontent.com/199614/86606162-55a13900-bfb0-11ea-8008-610c107b2aec.png)      | ![Screenshot_1594046940](https://user-images.githubusercontent.com/199614/86606753-158e8600-bfb1-11ea-95e7-c6df8c2605ed.png) | 

Example usage:
```js
<DatePickerAndroid
    style={{width: androidDatePickerWidth}}
    date={date}
    locale={i18n.language}
    dateFormat="EEE d. MMM"
    minimumDate={minimumDate}
    maximumDate={maximumDate}
    mode="datetime"
    onDateChange={onDateChange}
    testID="journey-planner-android-date-picker"
    timeZoneOffsetInMinutes={timeZoneOffsetInMinutes}
/>
```

Final outcome:
![Screenshot_1594036781](https://user-images.githubusercontent.com/199614/86606470-b92b6680-bfb0-11ea-8817-01e1546b53c7.png)
