### PR TITLE
adaptive am pm width

### DIFF
--- a/android/src/main/res/layout/native_picker.xml
+++ b/android/src/main/res/layout/native_picker.xml
@@ -52,7 +52,7 @@
         <com.henninghall.date_picker.pickers.AndroidNative
             android:id="@+id/ampm"
             android:theme="@style/android_native_theme"
-            style="@style/android_native_small"
+            style="@style/android_native"
             android:tag="ampm" />
     </LinearLayout>
 


### PR DESCRIPTION
fixes https://github.com/henninghall/react-native-date-picker/issues/210

<img width="223" alt="Screenshot 2020-07-26 at 19 46 09" src="https://user-images.githubusercontent.com/1652607/88485753-b94bd000-cf78-11ea-9b3e-eacc450137d4.png">
