### PR TITLE
Fix nynorsk (nn) locale by adding it to Formats

### DIFF
--- a/android/src/main/java/com/henninghall/date_picker/Formats.java
+++ b/android/src/main/java/com/henninghall/date_picker/Formats.java
@@ -99,6 +99,7 @@ public class Formats {
         put("nb", mapOf("EEE d. MMM", "d.", "y"));
         put("ne", mapOf("MMM d, EEE", "d", "y"));
         put("nl", mapOf("EEE d MMM", "d", "y"));
+        put("nn", mapOf("EEE d. MMM", "d.", "y"));
         put("no", mapOf("EEE d. MMM", "d.", "y"));
         put("no_NO", mapOf("EEE d. MMM", "d.", "y"));
         put("or", mapOf("EEE, MMM d", "d", "y"));


### PR DESCRIPTION
I seems like some locales were removed in this PR: https://github.com/henninghall/react-native-date-picker/pull/204 when DayFormats.java was replaced with Formats.java. This breaks the date picker for Norwegian Nynorsk (nn) on Android devices. Adding the locale in Formats.java fixes the issue for this particular locale.

Tested by editing directly in node_modules in our own app project. 