### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/react-native-date-picker.podspec
+++ b/react-native-date-picker.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/henninghall/react-native-date-picker.git" }
   s.source_files  = "ios/RNDatePicker/*.{h,m}"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
## Summary

Latest Xcode 12 fails to build while without a module to depend on React-Core directly hence this change is necessary for all native modules on iOS. For more details please check: facebook/react-native#29633

### Test Plan
Use this branch to install with an app running on Xcode 12.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)


