### PR TITLE
[android]fix:"DatePickerManager" was not found in the UIManager

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: {
+        "sourceDir": "./android",
+        "packageImportPath": "import com.henninghall.date_picker.DatePickerPackage;",
+        "packageInstance": "new DatePickerPackage()"
+      }
+    }
+  }
+};


### PR DESCRIPTION
autolink doc: [https://github.com/react-native-community/cli/blob/master/docs/autolinking.md](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md)
issues: #40 #44 #107 