### PR TITLE
fix: android native variant min/max scrolling issues

### DIFF
--- a/.github/workflows/android-detox.yml
+++ b/.github/workflows/android-detox.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   javascript_unit_tests:
-    name: Unit tests
+    name: Unit tests - javascript
     runs-on: macos-latest
     timeout-minutes: 5
 
@@ -32,6 +32,7 @@ jobs:
           yarn test
 
   java_unit_tests:
+    name: Unit tests - java
     runs-on: ubuntu-latest
 
     steps:
@@ -40,6 +41,11 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+
+      - name: Install npm dependencies
+        run: |
+          yarn install --frozen-lockfile
+
       - name: Run unit tests
         working-directory: ./examples/detox/android
         run: ./gradlew testDebugUnitTest

--- a/.github/workflows/android-detox.yml
+++ b/.github/workflows/android-detox.yml
@@ -43,6 +43,7 @@ jobs:
           java-version: 1.8
 
       - name: Install npm dependencies
+        working-directory: ./examples/detox
         run: |
           yarn install --frozen-lockfile
 

--- a/.github/workflows/android-detox.yml
+++ b/.github/workflows/android-detox.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  unit_tests:
+  javascript_unit_tests:
     name: Unit tests
     runs-on: macos-latest
     timeout-minutes: 5
@@ -30,6 +30,19 @@ jobs:
       - name: Run unit tests
         run: |
           yarn test
+
+  java_unit_tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Run unit tests
+        working-directory: ./examples/detox/android
+        run: ./gradlew testDebugUnitTest
 
   end_to_end_tests:
     name: End to end tests

--- a/android/src/main/java/com/henninghall/date_picker/Utils.java
+++ b/android/src/main/java/com/henninghall/date_picker/Utils.java
@@ -85,4 +85,17 @@ public class Utils {
             default: throw new Exception("Invalid pattern char: " + patternChar);
         }
     }
+
+
+    public static int getShortestScrollOption(int from, int to, final int maxValue, boolean isWrapping) {
+        int size = maxValue + 1;
+        int option1 = to - from;
+        int option2 = option1 > 0 ? option1 - size : option1 + size;
+        if (isWrapping) {
+            return Math.abs(option1) < Math.abs(option2) ? option1 : option2;
+        }
+        if (from + option1 > maxValue) return option2;
+        if (from + option1 < 0) return option2;
+        return option1;
+    }
 }

--- a/android/src/main/java/com/henninghall/date_picker/pickers/AndroidNative.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/AndroidNative.java
@@ -9,6 +9,8 @@ import android.view.View;
 import android.widget.EditText;
 import android.widget.NumberPicker;
 
+import com.henninghall.date_picker.Utils;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -105,7 +107,7 @@ public class AndroidNative extends NumberPicker implements Picker {
             public void run() {
                 int currentValue = self.getValue();
                 if (value == currentValue) return;
-                int shortestScrollOption = getShortestScrollOption(currentValue, value);
+                int shortestScrollOption = Utils.getShortestScrollOption(currentValue, value, getMaxValue(), getWrapSelectorWheel());
                 final int moves = Math.abs(shortestScrollOption);
                 for (int i = 0; i < moves; i++) {
                     // need some delay between each scroll step to make sure it scrolls to correct value
@@ -117,17 +119,6 @@ public class AndroidNative extends NumberPicker implements Picker {
         }, 500);
     }
 
-    private int getShortestScrollOption(int currentValue, int value) {
-        final int maxValue = getMaxValue();
-        int option1 = value - currentValue;
-        int option2 = maxValue + 1 - Math.abs(option1);
-        if (getWrapSelectorWheel()) {
-            return Math.abs(option1) < Math.abs(option2) ? option1 : option2;
-        }
-        if (currentValue + option1 > maxValue) return option2;
-        if (currentValue + option1 < 0) return option2;
-        return option1;
-    }
 
     private void changeValueByOne(final NumberPicker higherPicker, final boolean increment) {
         boolean success = false;

--- a/android/src/main/java/com/henninghall/date_picker/ui/WheelChangeListenerImpl.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/WheelChangeListenerImpl.java
@@ -40,7 +40,7 @@ public class WheelChangeListenerImpl implements WheelChangeListener {
     public void onChange(Wheel picker) {
         if(wheels.hasSpinningWheel()) return;
 
-        if(!exists()){
+        if(!dateExists()){
             Calendar closestExistingDate = getClosestExistingDateInPast();
             if(closestExistingDate != null) {
                 uiManager.animateToDate(closestExistingDate);
@@ -67,7 +67,7 @@ public class WheelChangeListenerImpl implements WheelChangeListener {
     }
 
     // Example: Jan 1 returns true, April 31 returns false.
-    private boolean exists(){
+    private boolean dateExists(){
         SimpleDateFormat dateFormat = getDateFormat();
         String toParse = wheels.getDateTimeString();
         try {

--- a/examples/detox/android/app/build.gradle
+++ b/examples/detox/android/app/build.gradle
@@ -78,6 +78,7 @@ dependencies {
 
     androidTestImplementation('com.wix:detox:+') { transitive = true }
     androidTestImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 }
 
 // Run this once to be able to run the application with BUCK

--- a/examples/detox/android/app/build.gradle
+++ b/examples/detox/android/app/build.gradle
@@ -5,7 +5,7 @@ import com.android.build.OutputFile
 apply from: "../../node_modules/react-native/react.gradle"
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion 28
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {

--- a/examples/detox/android/app/build.gradle
+++ b/examples/detox/android/app/build.gradle
@@ -5,7 +5,7 @@ import com.android.build.OutputFile
 apply from: "../../node_modules/react-native/react.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {

--- a/examples/detox/android/app/src/test/java/ShortestScrollOption.java
+++ b/examples/detox/android/app/src/test/java/ShortestScrollOption.java
@@ -1,0 +1,60 @@
+
+import com.henninghall.date_picker.Utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ShortestScrollOption {
+
+    @Test
+    public void decreaseOne() {
+        assertEquals( -1, Utils.getShortestScrollOption(1, 0, 10, false));
+    }
+
+    @Test
+    public void increaseOne() {
+        assertEquals(1, Utils.getShortestScrollOption(0, 1, 10, false));
+    }
+
+    @Test
+    public void increaseFive() {
+        assertEquals( 5, Utils.getShortestScrollOption(0, 5, 10, false));
+    }
+
+    @Test
+    public void noChange() {
+        assertEquals( 0, Utils.getShortestScrollOption(0, 0, 10, false));
+    }
+
+    @Test
+    public void noWrapping() {
+        assertEquals( 10, Utils.getShortestScrollOption(0, 10, 10, false));
+    }
+
+    @Test
+    public void wrapping() {
+        assertEquals( -1, Utils.getShortestScrollOption(0, 10, 10, true));
+    }
+
+    @Test
+    public void findingClosestByIncreaseNoWrap() {
+        assertEquals( 4, Utils.getShortestScrollOption(0, 4, 9, true));
+    }
+
+    @Test
+    public void findingClosestByIncreaseWrap() {
+        assertEquals( 4, Utils.getShortestScrollOption(6, 0, 9, true));
+    }
+
+    @Test
+    public void findingClosestByDecreaseNoWrap() {
+        assertEquals( -4, Utils.getShortestScrollOption(5, 1, 9, true));
+    }
+
+    @Test
+    public void findingClosestByDecreaseWrap() {
+        assertEquals( -4, Utils.getShortestScrollOption(0, 6, 9, true));
+    }
+
+}

--- a/src/propChecker.js
+++ b/src/propChecker.js
@@ -40,4 +40,10 @@ const modeCheck = new PropCheck(
   "Invalid mode. Valid modes: 'datetime', 'date', 'time'"
 )
 
-const checks = [widthCheck, heightCheck, modeCheck]
+const androidVariantCheck = new PropCheck(
+  props =>
+    props && props.androidVariant && !['nativeAndroid', 'iosClone'].includes(props.androidVariant),
+  "Invalid android variant. Valid modes: 'nativeAndroid', 'iosClone'"
+)
+
+const checks = [widthCheck, heightCheck, modeCheck, androidVariantCheck]


### PR DESCRIPTION
Fixes an issue occurring with setup: 
- android
- androidVariant: `nativeAndroid`
- scrolling below `minimumDate` or scrolling above `maximumDate`

This could cause the wheel to spin infinitely which lead to OutOfMemoryError

Fixes https://github.com/henninghall/react-native-date-picker/issues/264, https://github.com/henninghall/react-native-date-picker/issues/257