### PR TITLE
fix: bugs occurring on daylight saving day

### DIFF
--- a/android/src/main/java/com/henninghall/date_picker/wheels/AmPmWheel.java
+++ b/android/src/main/java/com/henninghall/date_picker/wheels/AmPmWheel.java
@@ -22,7 +22,7 @@ public class AmPmWheel extends Wheel {
         Calendar cal = Calendar.getInstance();
         ArrayList<String> values = new ArrayList<>();
 
-        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.HOUR_OF_DAY, 6);
         values.add(format.format(cal.getTime()));
 
         cal.add(Calendar.HOUR_OF_DAY, 12);

--- a/android/src/main/java/com/henninghall/date_picker/wheels/AmPmWheel.java
+++ b/android/src/main/java/com/henninghall/date_picker/wheels/AmPmWheel.java
@@ -20,9 +20,12 @@ public class AmPmWheel extends Wheel {
     @Override
     public ArrayList<String> getValues() {
         Calendar cal = Calendar.getInstance();
+        // Getting the hours from a date that will never have daylight saving to be sure
+        // cal.add() will work properly.
+        cal.set(2000,0,0,0,0,0);
         ArrayList<String> values = new ArrayList<>();
 
-        cal.set(Calendar.HOUR_OF_DAY, 6);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
         values.add(format.format(cal.getTime()));
 
         cal.add(Calendar.HOUR_OF_DAY, 12);

--- a/android/src/main/java/com/henninghall/date_picker/wheels/HourWheel.java
+++ b/android/src/main/java/com/henninghall/date_picker/wheels/HourWheel.java
@@ -19,6 +19,10 @@ public class HourWheel extends Wheel {
     @Override
     public ArrayList<String> getValues() {
         Calendar cal = Calendar.getInstance();
+        // Getting the hours from a date that doesn't have daylight saving to be sure
+        // cal.add() will work properly.
+        cal.set(2000,0,0,0,0,0);
+
         ArrayList<String> values = new ArrayList<>();
         int numberOfHours = state.derived.usesAmPm() ? 12 : 24;
 

--- a/examples/manual-tests/daylight-saving.md
+++ b/examples/manual-tests/daylight-saving.md
@@ -2,10 +2,18 @@
 
 I haven't found an automatic way to change the time on the emulator to be able to run these tests automatically.
 
-## Test: Make sure AM/PM wheel is rendered properly
+## Test: AM/PM wheel should have proper values
 
-1. Set the timezone to GMT-08:00 Pacific Standard Time.
+1. Set the timezone to GMT-07:00 Pacific Standard Time.
 1. Set the time to 2020-11-01
 1. Set 24h setting to false. (AM/PM=true)
-1. Go to any picker
+1. Go to time or datetime picker
 1. Expect: Both AM and PM being in visible in AM/PM wheel.
+
+## Test: Hour wheel should have proper values
+
+1. Set the timezone to GMT-07:00 Pacific Standard Time.
+1. Set the time to 2020-10-31 8:00 PM
+1. Set 24h setting to false. (AM/PM=true)
+1. Go to time or datetime picker.
+1. Expect: All hours to exist on hour wheel and no hour missing.

--- a/examples/manual-tests/daylight-saving.md
+++ b/examples/manual-tests/daylight-saving.md
@@ -1,0 +1,11 @@
+# Daylight saving testing
+
+I haven't found an automatic way to change the time on the emulator to be able to run these tests automatically.
+
+## Test: Make sure AM/PM wheel is rendered properly
+
+1. Set the timezone to GMT-08:00 Pacific Standard Time.
+1. Set the time to 2020-11-01
+1. Set 24h setting to false. (AM/PM=true)
+1. Go to any picker
+1. Expect: Both AM and PM being in visible in AM/PM wheel.


### PR DESCRIPTION
Fixes these daylight saving related bugs:
- am/am is shown in am/pm wheel
- an hour value is missing in hour wheel and a duplicated hour is added

Fixes https://github.com/henninghall/react-native-date-picker/issues/262