### PR TITLE
fix: android native variant stops responding at unmount during spinn

### DIFF
--- a/android/src/main/java/com/henninghall/date_picker/pickers/AndroidNative.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/AndroidNative.java
@@ -24,6 +24,7 @@ public class AndroidNative extends NumberPicker implements Picker {
     private int state = SCROLL_STATE_IDLE;
     private OnValueChangeListenerInScrolling listenerInScrolling;
     private boolean isAnimating;
+    private final Handler handler = new Handler();
 
     public AndroidNative(Context context) {
         super(context);
@@ -111,7 +112,7 @@ public class AndroidNative extends NumberPicker implements Picker {
         int timeBetweenScrollsMs = 100;
         int willStopScrollingInMs = timeBetweenScrollsMs * moves;
         isAnimating = true;
-        new Handler().postDelayed(new Runnable() {
+        handler.postDelayed(new Runnable() {
             @Override
             public void run() {
                 isAnimating = false;
@@ -149,7 +150,7 @@ public class AndroidNative extends NumberPicker implements Picker {
 
     private void changeValueByOne(final boolean increment, final int ms, final boolean isLast) {
         final AndroidNative self = this;
-        new Handler().postDelayed(new Runnable() {
+        handler.postDelayed(new Runnable() {
             @Override
             public void run() {
                 changeValueByOne(self, increment);
@@ -202,7 +203,7 @@ public class AndroidNative extends NumberPicker implements Picker {
     }
 
     private void sendEventIn500ms(){
-        new Handler().postDelayed(new Runnable() {
+        handler.postDelayed(new Runnable() {
             @Override
             public void run() {
                 onValueChangedListener.onValueChange();
@@ -211,4 +212,9 @@ public class AndroidNative extends NumberPicker implements Picker {
         }, 500);
     }
 
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        handler.removeCallbacksAndMessages(null);
+    }
 }


### PR DESCRIPTION
**Fixes #295**

The application stops responding when the react native date picker component is unmounted and there are pending post delayed callbacks yet to run on the AndroidNative.java picker.

**What I did:**

I've added a handler instance in the class and replaced all the inline new Handler() found in the class plus I've overridden the onDetachedFromWindow method so when the component is unmounted we can cancel all the pending callbacks and avoid the problem.

I've tested the fix with a patch package applied to the example repo that I've created to reproduce the issue (mentioned in #295) and applied to my working project too. Both tested with the AVD and some physical samsung devices.

