### PR TITLE
Feature - Add accessibility support for android date picker

### DIFF
--- a/android/src/main/java/com/henninghall/date_picker/LocaleUtils.java
+++ b/android/src/main/java/com/henninghall/date_picker/LocaleUtils.java
@@ -61,4 +61,29 @@ public class LocaleUtils {
         return df instanceof SimpleDateFormat && ((SimpleDateFormat) df).toPattern().contains("a");
     }
 
+    public static String getLocaleStringResource(Locale requestedLocale, int resourceId, Context context) {
+        String result;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) { // use latest api
+            Configuration config = new Configuration(context.getResources().getConfiguration());
+            config.setLocale(requestedLocale);
+            result = context.createConfigurationContext(config).getText(resourceId).toString();
+        }
+        else { // support older android versions
+            Resources resources = context.getResources();
+            Configuration conf = resources.getConfiguration();
+            Locale savedLocale = conf.locale;
+            conf.locale = requestedLocale;
+            resources.updateConfiguration(conf, null);
+
+            // retrieve resources from desired locale
+            result = resources.getString(resourceId);
+
+            // restore original locale
+            conf.locale = savedLocale;
+            resources.updateConfiguration(conf, null);
+        }
+
+        return result;
+    }
+
 }

--- a/android/src/main/java/com/henninghall/date_picker/LocaleUtils.java
+++ b/android/src/main/java/com/henninghall/date_picker/LocaleUtils.java
@@ -1,5 +1,10 @@
 package com.henninghall.date_picker;
 
+import android.content.Context;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.os.Build;
+
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Locale;

--- a/android/src/main/java/com/henninghall/date_picker/PickerView.java
+++ b/android/src/main/java/com/henninghall/date_picker/PickerView.java
@@ -72,6 +72,10 @@ public class PickerView extends RelativeLayout {
             uiManager.updateDisplayValues();
         }
 
+        if (didUpdate(ModeProp.name, LocaleProp.name)) {
+            uiManager.updateAccessibilityValues();
+        }
+
         uiManager.setWheelsToDate();
 
         updatedProps = new ArrayList<>();

--- a/android/src/main/java/com/henninghall/date_picker/Utils.java
+++ b/android/src/main/java/com/henninghall/date_picker/Utils.java
@@ -98,4 +98,10 @@ public class Utils {
         if (from + option1 < 0) return option2;
         return option1;
     }
+
+    public static String getLocalisedStringFromResources(Locale locale, String tagName) {
+        int selectedKey = DatePickerManager.context.getResources().getIdentifier(tagName,"string",DatePickerManager.context.getPackageName());
+        String localisedText = LocaleUtils.getLocaleStringResource(locale, selectedKey, DatePickerManager.context);
+        return localisedText;
+    }
 }

--- a/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
@@ -1,0 +1,80 @@
+package com.henninghall.date_picker.ui;
+
+import android.view.View;
+import android.view.accessibility.AccessibilityEvent;
+
+import com.henninghall.date_picker.State;
+import com.henninghall.date_picker.Utils;
+import com.henninghall.date_picker.wheelFunctions.WheelFunction;
+import com.henninghall.date_picker.wheels.Wheel;
+
+import java.util.Locale;
+
+public class Accessibility {
+
+    public static class SetAccessibilityDelegate implements WheelFunction {
+
+        private final Locale locale;
+
+        public SetAccessibilityDelegate(Locale locale) {
+            this.locale = locale;
+        }
+
+        @Override
+        public void apply(Wheel wheel) {
+            final View view = wheel.picker.getView();
+            view.setAccessibilityDelegate(
+                    new View.AccessibilityDelegate(){
+                        @Override
+                        public void onPopulateAccessibilityEvent(View host, AccessibilityEvent event) {
+                            super.onPopulateAccessibilityEvent(host, event);
+                            if (event.getEventType() == AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED) {
+                                String resourceKey = view.getTag().toString()+"_description";
+                                String localeTag =  Utils.getLocalisedStringFromResources(locale, resourceKey);
+                                // Screen reader reads the content description when focused on each picker wheel
+                                view.setContentDescription(localeTag);
+                            }
+                        }
+                    }
+            );
+        }
+    }
+
+    private final State state;
+    private final Wheels wheels;
+
+    public Accessibility(State state, Wheels wheels){
+        this.state = state;
+        this.wheels = wheels;
+    }
+
+    public void update(Wheel picker){
+        String tagName = picker.picker.getView().getTag().toString();
+        String selectedDateString = getAccessibleTextForSelectedDate();
+        String descriptionPrefix = Utils.getLocalisedStringFromResources(state.getLocale(), "selected_"+tagName+"_description");
+        String descriptionPostFix = Utils.getLocalisedStringFromResources(state.getLocale(), "selected_value_description");
+
+        picker.picker.getView().setContentDescription(descriptionPrefix + ", "+ descriptionPostFix + " "+ selectedDateString);
+    }
+
+    private String getAccessibleTextForSelectedDate() {
+        String accessibleText;
+        switch(state.getMode()) {
+            case date:
+                accessibleText = wheels.getDateString();
+                break;
+            case time:
+                accessibleText = wheels.getTimeString();
+                break;
+            default:
+                // default is dateTime
+                String timePrefix = Utils.getLocalisedStringFromResources(state.getLocale(), "time_tag");
+                String hourPrefix = Utils.getLocalisedStringFromResources(state.getLocale(), "hour_tag");
+                String minutesPrefix = Utils.getLocalisedStringFromResources(state.getLocale(), "minutes_tag");
+                accessibleText = wheels.getAccessibleDateTimeString(timePrefix, hourPrefix, minutesPrefix);
+                break;
+        }
+        return accessibleText;
+    }
+
+}

--- a/android/src/main/java/com/henninghall/date_picker/ui/UIManager.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/UIManager.java
@@ -7,7 +7,6 @@ import com.henninghall.date_picker.wheelFunctions.AddOnChangeListener;
 import com.henninghall.date_picker.wheelFunctions.AnimateToDate;
 import com.henninghall.date_picker.wheelFunctions.Refresh;
 import com.henninghall.date_picker.wheelFunctions.SetDate;
-import com.henninghall.date_picker.wheelFunctions.SetDividerHeight;
 import com.henninghall.date_picker.wheelFunctions.TextColor;
 import com.henninghall.date_picker.wheelFunctions.UpdateVisibility;
 import com.henninghall.date_picker.wheelFunctions.HorizontalPadding;
@@ -22,11 +21,13 @@ public class UIManager {
     private Wheels wheels;
     private FadingOverlay fadingOverlay;
     private WheelScroller wheelScroller = new WheelScroller();
+    private Accessibility accessibility;
 
     public UIManager(State state, View rootView){
         this.state = state;
         this.rootView = rootView;
         wheels = new Wheels(state, rootView);
+        accessibility = new Accessibility(state, wheels);
         addOnChangeListener();
     }
 
@@ -89,5 +90,13 @@ public class UIManager {
 
     public void updateWheelPadding() {
         wheels.applyOnVisible(new HorizontalPadding());
+    }
+
+    public void updateContentDescription(Wheel picker) {
+        accessibility.update(picker);
+    }
+
+    public void updateAccessibilityValues() {
+        wheels.applyOnAll(new Accessibility.SetAccessibilityDelegate(state.getLocale()));
     }
 }

--- a/android/src/main/java/com/henninghall/date_picker/ui/WheelChangeListenerImpl.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/WheelChangeListenerImpl.java
@@ -83,7 +83,10 @@ public class WheelChangeListenerImpl implements WheelChangeListener {
 
         String tagName = picker.picker.getView().getTag().toString();
         String selectedDateString = getAccessibleTextForSelectedDate();
-        picker.picker.getView().setContentDescription("Selected"+ tagName + ", Value is: "+ selectedDateString);
+        String descriptionPrefix = Utils.getLocalisedStringFromResources(state.getLocale(), "selected_"+tagName+"_description");
+        String descriptionPostFix = Utils.getLocalisedStringFromResources(state.getLocale(), "selected_value_description");
+
+        picker.picker.getView().setContentDescription(descriptionPrefix + ", "+ descriptionPostFix + " "+ selectedDateString);
         emitDateChangeEvent(selectedDate);
     }
 

--- a/android/src/main/java/com/henninghall/date_picker/ui/WheelChangeListenerImpl.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/WheelChangeListenerImpl.java
@@ -63,6 +63,8 @@ public class WheelChangeListenerImpl implements WheelChangeListener {
             return;
         }
 
+        String tagName = picker.picker.getTag().toString();
+        picker.picker.setContentDescription("Selected"+ tagName + ", Value is: "+ selectedDate);
         emitDateChangeEvent(selectedDate);
     }
 

--- a/android/src/main/java/com/henninghall/date_picker/ui/WheelChangeListenerImpl.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/WheelChangeListenerImpl.java
@@ -36,6 +36,24 @@ public class WheelChangeListenerImpl implements WheelChangeListener {
         return dateFormat;
     }
 
+    
+    private String getAccessibleTextForSelectedDate() {
+        String accessibleText;
+        switch(state.getMode()) {
+            case date:
+                accessibleText = wheels.getDateString();
+                break;
+            case time:
+                accessibleText = wheels.getTimeString();
+                break;
+            default:
+                // default is dateTime
+                accessibleText = wheels.getDateTimeString();
+                break;
+        }
+        return accessibleText;
+    }
+
     @Override
     public void onChange(Wheel picker) {
         if(wheels.hasSpinningWheel()) return;
@@ -63,8 +81,9 @@ public class WheelChangeListenerImpl implements WheelChangeListener {
             return;
         }
 
-        String tagName = picker.picker.getTag().toString();
-        picker.picker.setContentDescription("Selected"+ tagName + ", Value is: "+ selectedDate);
+        String tagName = picker.picker.getView().getTag().toString();
+        String selectedDateString = getAccessibleTextForSelectedDate();
+        picker.picker.getView().setContentDescription("Selected"+ tagName + ", Value is: "+ selectedDateString);
         emitDateChangeEvent(selectedDate);
     }
 

--- a/android/src/main/java/com/henninghall/date_picker/ui/WheelChangeListenerImpl.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/WheelChangeListenerImpl.java
@@ -36,27 +36,6 @@ public class WheelChangeListenerImpl implements WheelChangeListener {
         return dateFormat;
     }
 
-    
-    private String getAccessibleTextForSelectedDate() {
-        String accessibleText;
-        switch(state.getMode()) {
-            case date:
-                accessibleText = wheels.getDateString();
-                break;
-            case time:
-                accessibleText = wheels.getTimeString();
-                break;
-            default:
-                // default is dateTime
-                String timePrefix = Utils.getLocalisedStringFromResources(state.getLocale(), "time_tag");
-                String hourPrefix = Utils.getLocalisedStringFromResources(state.getLocale(), "hour_tag");
-                String minutesPrefix = Utils.getLocalisedStringFromResources(state.getLocale(), "minutes_tag");
-                accessibleText = wheels.getAccessibleDateTimeString(timePrefix, hourPrefix, minutesPrefix);
-                break;
-        }
-        return accessibleText;
-    }
-
     @Override
     public void onChange(Wheel picker) {
         if(wheels.hasSpinningWheel()) return;
@@ -84,12 +63,8 @@ public class WheelChangeListenerImpl implements WheelChangeListener {
             return;
         }
 
-        String tagName = picker.picker.getView().getTag().toString();
-        String selectedDateString = getAccessibleTextForSelectedDate();
-        String descriptionPrefix = Utils.getLocalisedStringFromResources(state.getLocale(), "selected_"+tagName+"_description");
-        String descriptionPostFix = Utils.getLocalisedStringFromResources(state.getLocale(), "selected_value_description");
+        uiManager.updateContentDescription(picker);
 
-        picker.picker.getView().setContentDescription(descriptionPrefix + ", "+ descriptionPostFix + " "+ selectedDateString);
         emitDateChangeEvent(selectedDate);
     }
 

--- a/android/src/main/java/com/henninghall/date_picker/ui/WheelChangeListenerImpl.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/WheelChangeListenerImpl.java
@@ -48,7 +48,10 @@ public class WheelChangeListenerImpl implements WheelChangeListener {
                 break;
             default:
                 // default is dateTime
-                accessibleText = wheels.getDateTimeString();
+                String timePrefix = Utils.getLocalisedStringFromResources(state.getLocale(), "time_tag");
+                String hourPrefix = Utils.getLocalisedStringFromResources(state.getLocale(), "hour_tag");
+                String minutesPrefix = Utils.getLocalisedStringFromResources(state.getLocale(), "minutes_tag");
+                accessibleText = wheels.getAccessibleDateTimeString(timePrefix, hourPrefix, minutesPrefix);
                 break;
         }
         return accessibleText;

--- a/android/src/main/java/com/henninghall/date_picker/ui/Wheels.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Wheels.java
@@ -1,6 +1,7 @@
 package com.henninghall.date_picker.ui;
 
 import android.view.View;
+import android.view.accessibility.AccessibilityEvent;
 
 import com.henninghall.date_picker.Utils;
 import com.henninghall.date_picker.models.Variant;
@@ -63,11 +64,19 @@ public class Wheels {
         changeAmPmWhenPassingMidnightOrNoon();
     }
 
-    private Picker getPickerWithId(int id){
-        String resourceKey =  rootView.findViewById(id).getTag().toString()+"_description";
-        String localeTag =  Utils.getLocalisedStringFromResources(state.getLocale(), resourceKey);
-        // Screen reader reads the content description when focused on each picker wheel
-        rootView.findViewById(id).setContentDescription(localeTag);
+    private Picker getPickerWithId(final int id){
+        rootView.findViewById(id).setAccessibilityDelegate(new View.AccessibilityDelegate(){
+            @Override
+            public void onPopulateAccessibilityEvent(View host, AccessibilityEvent event) {
+                super.onPopulateAccessibilityEvent(host, event);
+                if (event.getEventType() == AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED) {
+                    String resourceKey =  rootView.findViewById(id).getTag().toString()+"_description";
+                    String localeTag =  Utils.getLocalisedStringFromResources(state.getLocale(), resourceKey);
+                    // Screen reader reads the content description when focused on each picker wheel
+                    rootView.findViewById(id).setContentDescription(localeTag);
+                }
+            }
+        });
         return (Picker) rootView.findViewById(id);
     }
 
@@ -149,6 +158,15 @@ public class Wheels {
 
     String getDateTimeString() {
         return getDateTimeString(0);
+    }
+
+    String getAccessibleDateTimeString(String timePrefix, String hourTag, String minutesTag) {
+        String date = getDateString(0);
+        String hour = hourWheel.getValue();
+        String minutes = minutesWheel.getValue();
+        String ampm = ampmWheel.getValue();
+        String time = timePrefix+ " "+ hour + hourTag + minutes + minutesTag + ampm;
+        return date+", "+ time;
     }
 
     String getDateString() {

--- a/android/src/main/java/com/henninghall/date_picker/ui/Wheels.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Wheels.java
@@ -1,9 +1,7 @@
 package com.henninghall.date_picker.ui;
 
 import android.view.View;
-import android.view.accessibility.AccessibilityEvent;
 
-import com.henninghall.date_picker.Utils;
 import com.henninghall.date_picker.models.Variant;
 import com.henninghall.date_picker.pickers.Picker;
 import com.henninghall.date_picker.R;
@@ -65,18 +63,6 @@ public class Wheels {
     }
 
     private Picker getPickerWithId(final int id){
-        rootView.findViewById(id).setAccessibilityDelegate(new View.AccessibilityDelegate(){
-            @Override
-            public void onPopulateAccessibilityEvent(View host, AccessibilityEvent event) {
-                super.onPopulateAccessibilityEvent(host, event);
-                if (event.getEventType() == AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED) {
-                    String resourceKey =  rootView.findViewById(id).getTag().toString()+"_description";
-                    String localeTag =  Utils.getLocalisedStringFromResources(state.getLocale(), resourceKey);
-                    // Screen reader reads the content description when focused on each picker wheel
-                    rootView.findViewById(id).setContentDescription(localeTag);
-                }
-            }
-        });
         return (Picker) rootView.findViewById(id);
     }
 
@@ -160,8 +146,12 @@ public class Wheels {
         return getDateTimeString(0);
     }
 
+    String getDateString() {
+        return getDateString(0);
+    }
+
     String getAccessibleDateTimeString(String timePrefix, String hourTag, String minutesTag) {
-        String date = getDateString(0);
+        String date = getDateString();
         String hour = hourWheel.getValue();
         String minutes = minutesWheel.getValue();
         String ampm = ampmWheel.getValue();
@@ -169,10 +159,6 @@ public class Wheels {
         return date+", "+ time;
     }
 
-    String getDateString() {
-        return getDateString(0);
-    }
-    
     String getDisplayValue() {
         StringBuilder sb = new StringBuilder();
         for (Wheel wheel: getOrderedVisibleWheels()) {

--- a/android/src/main/java/com/henninghall/date_picker/ui/Wheels.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Wheels.java
@@ -2,6 +2,7 @@ package com.henninghall.date_picker.ui;
 
 import android.view.View;
 
+import com.henninghall.date_picker.Utils;
 import com.henninghall.date_picker.models.Variant;
 import com.henninghall.date_picker.pickers.Picker;
 import com.henninghall.date_picker.R;
@@ -63,6 +64,10 @@ public class Wheels {
     }
 
     private Picker getPickerWithId(int id){
+        String resourceKey =  rootView.findViewById(id).getTag().toString()+"_description";
+        String localeTag =  Utils.getLocalisedStringFromResources(state.getLocale(), resourceKey);
+        // Screen reader reads the content description when focused on each picker wheel
+        rootView.findViewById(id).setContentDescription(localeTag);
         return (Picker) rootView.findViewById(id);
     }
 

--- a/android/src/main/java/com/henninghall/date_picker/ui/Wheels.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Wheels.java
@@ -136,7 +136,7 @@ public class Wheels {
         return dayWheel.getValue();
     }
 
-    private String getTimeString(){
+    String getTimeString(){
         return hourWheel.getValue()
                 + " " + minutesWheel.getValue()
                 + ampmWheel.getValue();
@@ -146,6 +146,10 @@ public class Wheels {
         return getDateTimeString(0);
     }
 
+    String getDateString() {
+        return getDateString(0);
+    }
+    
     String getDisplayValue() {
         StringBuilder sb = new StringBuilder();
         for (Wheel wheel: getOrderedVisibleWheels()) {

--- a/android/src/main/res/layout/ios_clone.xml
+++ b/android/src/main/res/layout/ios_clone.xml
@@ -179,7 +179,6 @@
             android:id="@+id/overlay_bottom"
             android:src="@drawable/overlay"
             android:layout_width="match_parent"
-            android:contentDescription="@string/overlay"
             android:layout_height="0dp"
             android:layout_weight=".15"
         />

--- a/android/src/main/res/layout/ios_clone.xml
+++ b/android/src/main/res/layout/ios_clone.xml
@@ -34,7 +34,10 @@
             custom:npv_TextSizeSelected="21dp"
             custom:npv_TextColorSelected="#000000"
             custom:npv_TextColorNormal="#aaaaaa"
-            custom:npv_DividerColor="#cccccc" />
+            custom:npv_DividerColor="#cccccc"
+            android:contentDescription="Select Year"
+            android:focusable="true"
+            android:focusableInTouchMode="true" />
 
         <com.henninghall.date_picker.pickers.IosClone
             android:id="@+id/month"
@@ -49,6 +52,9 @@
             custom:npv_TextColorSelected="#000000"
             custom:npv_TextColorNormal="#aaaaaa"
             custom:npv_DividerColor="#cccccc"
+            android:contentDescription="Select Month"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
             />
 
         <com.henninghall.date_picker.pickers.IosClone
@@ -64,6 +70,9 @@
             custom:npv_TextColorSelected="#000000"
             custom:npv_TextColorNormal="#aaaaaa"
             custom:npv_DividerColor="#cccccc"
+            android:contentDescription="Select Date"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
             />
         <com.henninghall.date_picker.pickers.IosClone
             android:id="@+id/day"
@@ -77,6 +86,9 @@
             custom:npv_TextColorSelected="#000000"
             custom:npv_TextColorNormal="#aaaaaa"
             custom:npv_DividerColor="#cccccc"
+            android:contentDescription="Select Day"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
             />
         <com.henninghall.date_picker.pickers.IosClone
             android:id="@+id/hour"
@@ -91,6 +103,9 @@
             custom:npv_TextColorSelected="#000000"
             custom:npv_TextSizeNormal="18dp"
             custom:npv_TextSizeSelected="21dp"
+            android:contentDescription="Select Hour"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
             />
         <com.henninghall.date_picker.pickers.IosClone
             android:id="@+id/minutes"
@@ -105,6 +120,9 @@
             custom:npv_TextColorSelected="#000000"
             custom:npv_TextSizeNormal="18dp"
             custom:npv_TextSizeSelected="21dp"
+            android:contentDescription="Select Minutes"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
         />
 
         <com.henninghall.date_picker.pickers.IosClone
@@ -120,6 +138,9 @@
             custom:npv_TextColorSelected="#000000"
             custom:npv_TextSizeNormal="18dp"
             custom:npv_TextSizeSelected="21dp"
+            android:contentDescription="Select AM/PM"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
             />
             
         <com.henninghall.date_picker.pickers.IosClone

--- a/android/src/main/res/layout/ios_clone.xml
+++ b/android/src/main/res/layout/ios_clone.xml
@@ -120,7 +120,7 @@
             custom:npv_TextColorSelected="#000000"
             custom:npv_TextSizeNormal="18dp"
             custom:npv_TextSizeSelected="21dp"
-            android:contentDescription="@string/minute_description"
+            android:contentDescription="@string/minutes_description"
             android:focusable="true"
             android:focusableInTouchMode="true"
         />
@@ -138,7 +138,7 @@
             custom:npv_TextColorSelected="#000000"
             custom:npv_TextSizeNormal="18dp"
             custom:npv_TextSizeSelected="21dp"
-            android:contentDescription="@string/am_pm_description"
+            android:contentDescription="@string/ampm_description"
             android:focusable="true"
             android:focusableInTouchMode="true"
             />

--- a/android/src/main/res/layout/ios_clone.xml
+++ b/android/src/main/res/layout/ios_clone.xml
@@ -35,7 +35,7 @@
             custom:npv_TextColorSelected="#000000"
             custom:npv_TextColorNormal="#aaaaaa"
             custom:npv_DividerColor="#cccccc"
-            android:contentDescription="Select Year"
+            android:contentDescription="@string/year_description"
             android:focusable="true"
             android:focusableInTouchMode="true" />
 
@@ -52,7 +52,7 @@
             custom:npv_TextColorSelected="#000000"
             custom:npv_TextColorNormal="#aaaaaa"
             custom:npv_DividerColor="#cccccc"
-            android:contentDescription="Select Month"
+            android:contentDescription="@string/month_description"
             android:focusable="true"
             android:focusableInTouchMode="true"
             />
@@ -70,7 +70,7 @@
             custom:npv_TextColorSelected="#000000"
             custom:npv_TextColorNormal="#aaaaaa"
             custom:npv_DividerColor="#cccccc"
-            android:contentDescription="Select Date"
+            android:contentDescription="@string/date_description"
             android:focusable="true"
             android:focusableInTouchMode="true"
             />
@@ -86,7 +86,7 @@
             custom:npv_TextColorSelected="#000000"
             custom:npv_TextColorNormal="#aaaaaa"
             custom:npv_DividerColor="#cccccc"
-            android:contentDescription="Select Day"
+            android:contentDescription="@string/day_description"
             android:focusable="true"
             android:focusableInTouchMode="true"
             />
@@ -103,7 +103,7 @@
             custom:npv_TextColorSelected="#000000"
             custom:npv_TextSizeNormal="18dp"
             custom:npv_TextSizeSelected="21dp"
-            android:contentDescription="Select Hour"
+            android:contentDescription="@string/hour_description"
             android:focusable="true"
             android:focusableInTouchMode="true"
             />
@@ -120,7 +120,7 @@
             custom:npv_TextColorSelected="#000000"
             custom:npv_TextSizeNormal="18dp"
             custom:npv_TextSizeSelected="21dp"
-            android:contentDescription="Select Minutes"
+            android:contentDescription="@string/minute_description"
             android:focusable="true"
             android:focusableInTouchMode="true"
         />
@@ -138,7 +138,7 @@
             custom:npv_TextColorSelected="#000000"
             custom:npv_TextSizeNormal="18dp"
             custom:npv_TextSizeSelected="21dp"
-            android:contentDescription="Select AM/PM"
+            android:contentDescription="@string/am_pm_description"
             android:focusable="true"
             android:focusableInTouchMode="true"
             />

--- a/android/src/main/res/layout/native_picker.xml
+++ b/android/src/main/res/layout/native_picker.xml
@@ -17,43 +17,64 @@
             android:id="@+id/year"
             android:theme="@style/android_native_theme"
             style="@style/android_native"
-            android:tag="year" />
+            android:tag="year"
+            android:contentDescription="Select Year"
+            android:focusable="true"
+            android:focusableInTouchMode="true" />
 
         <com.henninghall.date_picker.pickers.AndroidNative
             android:id="@+id/month"
             android:theme="@style/android_native_theme"
             style="@style/android_native"
-            android:tag="month" />
+            android:tag="month"
+            android:contentDescription="Select Month"
+            android:focusable="true"
+            android:focusableInTouchMode="true" />
 
         <com.henninghall.date_picker.pickers.AndroidNative
             android:id="@+id/date"
             android:theme="@style/android_native_theme"
             style="@style/android_native_small"
-            android:tag="date" />
+            android:tag="date"
+            android:contentDescription="Select Date"
+            android:focusable="true"
+            android:focusableInTouchMode="true" />
 
         <com.henninghall.date_picker.pickers.AndroidNative
             android:id="@+id/day"
             android:theme="@style/android_native_theme"
             style="@style/android_native"
-            android:tag="day" />
+            android:tag="day"
+            android:contentDescription="Select Day"
+            android:focusable="true"
+            android:focusableInTouchMode="true" />
 
         <com.henninghall.date_picker.pickers.AndroidNative
             android:id="@+id/hour"
             android:theme="@style/android_native_theme"
             style="@style/android_native_small"
-            android:tag="hour" />
+            android:tag="hour"
+            android:contentDescription="Select Hour"
+            android:focusable="true"
+            android:focusableInTouchMode="true" />
 
         <com.henninghall.date_picker.pickers.AndroidNative
             android:id="@+id/minutes"
             android:theme="@style/android_native_theme"
             style="@style/android_native_small"
-            android:tag="minutes" />
+            android:tag="minutes"
+            android:contentDescription="Select Minutes"
+            android:focusable="true"
+            android:focusableInTouchMode="true" />
 
         <com.henninghall.date_picker.pickers.AndroidNative
             android:id="@+id/ampm"
             android:theme="@style/android_native_theme"
             style="@style/android_native"
-            android:tag="ampm" />
+            android:tag="ampm"
+            android:contentDescription="Select AM/PM"
+            android:focusable="true"
+            android:focusableInTouchMode="true" />
     </LinearLayout>
 
 </LinearLayout>

--- a/android/src/main/res/layout/native_picker.xml
+++ b/android/src/main/res/layout/native_picker.xml
@@ -18,7 +18,7 @@
             android:theme="@style/android_native_theme"
             style="@style/android_native"
             android:tag="year"
-            android:contentDescription="Select Year"
+            android:contentDescription="@string/year_description"
             android:focusable="true"
             android:focusableInTouchMode="true" />
 
@@ -27,7 +27,7 @@
             android:theme="@style/android_native_theme"
             style="@style/android_native"
             android:tag="month"
-            android:contentDescription="Select Month"
+            android:contentDescription="@string/month_description"
             android:focusable="true"
             android:focusableInTouchMode="true" />
 
@@ -36,7 +36,7 @@
             android:theme="@style/android_native_theme"
             style="@style/android_native_small"
             android:tag="date"
-            android:contentDescription="Select Date"
+            android:contentDescription="@string/date_description"
             android:focusable="true"
             android:focusableInTouchMode="true" />
 
@@ -45,7 +45,7 @@
             android:theme="@style/android_native_theme"
             style="@style/android_native"
             android:tag="day"
-            android:contentDescription="Select Day"
+            android:contentDescription="@string/day_description"
             android:focusable="true"
             android:focusableInTouchMode="true" />
 
@@ -54,7 +54,7 @@
             android:theme="@style/android_native_theme"
             style="@style/android_native_small"
             android:tag="hour"
-            android:contentDescription="Select Hour"
+            android:contentDescription="@string/hour_description"
             android:focusable="true"
             android:focusableInTouchMode="true" />
 
@@ -63,7 +63,7 @@
             android:theme="@style/android_native_theme"
             style="@style/android_native_small"
             android:tag="minutes"
-            android:contentDescription="Select Minutes"
+            android:contentDescription="@string/minute_description"
             android:focusable="true"
             android:focusableInTouchMode="true" />
 
@@ -72,7 +72,7 @@
             android:theme="@style/android_native_theme"
             style="@style/android_native"
             android:tag="ampm"
-            android:contentDescription="Select AM/PM"
+            android:contentDescription="@string/am_pm_description"
             android:focusable="true"
             android:focusableInTouchMode="true" />
     </LinearLayout>

--- a/android/src/main/res/layout/native_picker.xml
+++ b/android/src/main/res/layout/native_picker.xml
@@ -63,7 +63,7 @@
             android:theme="@style/android_native_theme"
             style="@style/android_native_small"
             android:tag="minutes"
-            android:contentDescription="@string/minute_description"
+            android:contentDescription="@string/minutes_description"
             android:focusable="true"
             android:focusableInTouchMode="true" />
 
@@ -72,7 +72,7 @@
             android:theme="@style/android_native_theme"
             style="@style/android_native"
             android:tag="ampm"
-            android:contentDescription="@string/am_pm_description"
+            android:contentDescription="@string/ampm_description"
             android:focusable="true"
             android:focusableInTouchMode="true" />
     </LinearLayout>

--- a/android/src/main/res/values-fi/strings.xml
+++ b/android/src/main/res/values-fi/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="overlay">Päivämääränvalitsimen peite</string>
+    <string name="year_description">Valitse Vuosi</string>
+    <string name="month_description">Valitse Kuukausi</string>
+    <string name="date_description">Valitse Päivämäärä</string>
+    <string name="day_description">Valitse Päivä</string>
+    <string name="hour_description">Valitse Tunti</string>
+    <string name="minute_description">Valitse Minuutit</string>
+    <string name="am_pm_description">Valitse am/pm</string>
+</resources>

--- a/android/src/main/res/values-fi/strings.xml
+++ b/android/src/main/res/values-fi/strings.xml
@@ -16,4 +16,7 @@
     <string name="selected_minutes_description">Valittu Minuutit</string>
     <string name="selected_ampm_description">Valittu am/pm</string>
     <string name="selected_value_description">Arvo on</string>
+    <string name="time_tag">Kello on</string>
+    <string name="hour_tag">Tunnin :</string>
+    <string name="minutes_tag">Pöytäkirja</string>
 </resources>

--- a/android/src/main/res/values-fi/strings.xml
+++ b/android/src/main/res/values-fi/strings.xml
@@ -6,6 +6,14 @@
     <string name="date_description">Valitse Päivämäärä</string>
     <string name="day_description">Valitse Päivä</string>
     <string name="hour_description">Valitse Tunti</string>
-    <string name="minute_description">Valitse Minuutit</string>
-    <string name="am_pm_description">Valitse am/pm</string>
+    <string name="minutes_description">Valitse Minuutit</string>
+    <string name="ampm_description">Valitse am/pm</string>
+    <string name="selected_year_description">Valittu Vuosi</string>
+    <string name="selected_month_description">Valittu Kuukausi</string>
+    <string name="selected_date_description">Valittu Päivämäärä</string>
+    <string name="selected_day_description">Valittu Päivä</string>
+    <string name="selected_hour_description">Valittu Tunti</string>
+    <string name="selected_minutes_description">Valittu Minuutit</string>
+    <string name="selected_ampm_description">Valittu am/pm</string>
+    <string name="selected_value_description">Arvo on</string>
 </resources>

--- a/android/src/main/res/values-fi/strings.xml
+++ b/android/src/main/res/values-fi/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="overlay">Päivämääränvalitsimen peite</string>
+    <string name="overlay">Päivämääränvalitsimen päällekkäin</string>
     <string name="year_description">Valitse Vuosi</string>
     <string name="month_description">Valitse Kuukausi</string>
     <string name="date_description">Valitse Päivämäärä</string>
@@ -13,10 +13,10 @@
     <string name="selected_date_description">Valittu Päivämäärä</string>
     <string name="selected_day_description">Valittu Päivä</string>
     <string name="selected_hour_description">Valittu Tunti</string>
-    <string name="selected_minutes_description">Valittu Minuutit</string>
+    <string name="selected_minutes_description">Valitut Minuutit</string>
     <string name="selected_ampm_description">Valittu am/pm</string>
     <string name="selected_value_description">Arvo on</string>
     <string name="time_tag">Kello on</string>
-    <string name="hour_tag">Tunnin :</string>
-    <string name="minutes_tag">Pöytäkirja</string>
+    <string name="hour_tag">Tunti:</string>
+    <string name="minutes_tag">Minuutit</string>
 </resources>

--- a/android/src/main/res/values-sv/strings.xml
+++ b/android/src/main/res/values-sv/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="overlay">Överlagring av datumväljare</string>
+    <string name="year_description">Välj år</string>
+    <string name="month_description">Välj månad</string>
+    <string name="date_description">Välj datum</string>
+    <string name="day_description">Välj dag</string>
+    <string name="hour_description">Välj timme</string>
+    <string name="minute_description">Välj minuter</string>
+    <string name="am_pm_description">Välj am/pm</string>
+</resources>

--- a/android/src/main/res/values-sv/strings.xml
+++ b/android/src/main/res/values-sv/strings.xml
@@ -16,4 +16,7 @@
     <string name="selected_minutes_description">Valt minuter</string>
     <string name="selected_ampm_description">Valt am/pm</string>
     <string name="selected_value_description">Värde är</string>
+    <string name="time_tag">Tiden är</string>
+    <string name="hour_tag">Timme :</string>
+    <string name="minutes_tag">Minuter</string>
 </resources>

--- a/android/src/main/res/values-sv/strings.xml
+++ b/android/src/main/res/values-sv/strings.xml
@@ -6,6 +6,14 @@
     <string name="date_description">Välj datum</string>
     <string name="day_description">Välj dag</string>
     <string name="hour_description">Välj timme</string>
-    <string name="minute_description">Välj minuter</string>
-    <string name="am_pm_description">Välj am/pm</string>
+    <string name="minutes_description">Välj minuter</string>
+    <string name="ampm_description">Välj am/pm</string>
+    <string name="selected_year_description">Valt år</string>
+    <string name="selected_month_description">Valt månad</string>
+    <string name="selected_date_description">Valt datum</string>
+    <string name="selected_day_description">Valt dag</string>
+    <string name="selected_hour_description">Valt timme</string>
+    <string name="selected_minutes_description">Valt minuter</string>
+    <string name="selected_ampm_description">Valt am/pm</string>
+    <string name="selected_value_description">Värde är</string>
 </resources>

--- a/android/src/main/res/values-sv/strings.xml
+++ b/android/src/main/res/values-sv/strings.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="overlay">Överlagring av datumväljare</string>
-    <string name="year_description">Välj år</string>
-    <string name="month_description">Välj månad</string>
-    <string name="date_description">Välj datum</string>
-    <string name="day_description">Välj dag</string>
-    <string name="hour_description">Välj timme</string>
+    <string name="overlay">Datumväljare på</string>
+    <string name="year_description">Välj ett år</string>
+    <string name="month_description">Välj en månad</string>
+    <string name="date_description">Välj ett datum</string>
+    <string name="day_description">Välj en dag</string>
+    <string name="hour_description">Välj en timme</string>
     <string name="minutes_description">Välj minuter</string>
     <string name="ampm_description">Välj am/pm</string>
     <string name="selected_year_description">Valt år</string>
     <string name="selected_month_description">Valt månad</string>
     <string name="selected_date_description">Valt datum</string>
-    <string name="selected_day_description">Valt dag</string>
-    <string name="selected_hour_description">Valt timme</string>
-    <string name="selected_minutes_description">Valt minuter</string>
-    <string name="selected_ampm_description">Valt am/pm</string>
-    <string name="selected_value_description">Värde är</string>
+    <string name="selected_day_description">Vald dag</string>
+    <string name="selected_hour_description">Vald timme</string>
+    <string name="selected_minutes_description">Valda minuter</string>
+    <string name="selected_ampm_description">Vald am/pm</string>
+    <string name="selected_value_description">Värdet är</string>
     <string name="time_tag">Tiden är</string>
-    <string name="hour_tag">Timme :</string>
+    <string name="hour_tag">Timme:</string>
     <string name="minutes_tag">Minuter</string>
 </resources>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,4 +1,11 @@
 <resources>
     <string name="app_name">react-native-date-picker</string>
     <string name="overlay">Date Picker Overlay</string>
+    <string name="year_description">Select Year</string>
+    <string name="month_description">Select Month</string>
+    <string name="date_description">Select Date</string>
+    <string name="day_description">Select Day</string>
+    <string name="hour_description">Select Hour</string>
+    <string name="minute_description">Select Minutes</string>
+    <string name="am_pm_description">Select AM/PM</string>
 </resources>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -16,4 +16,7 @@
     <string name="selected_minutes_description">Selected Minutes</string>
     <string name="selected_ampm_description">Selected AM/PM</string>
     <string name="selected_value_description">Value is</string>
+    <string name="time_tag">Time is</string>
+    <string name="hour_tag">Hour :</string>
+    <string name="minutes_tag">Minutes </string>
 </resources>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
     <string name="app_name">react-native-date-picker</string>
-    <string name="overlay">overlay</string>
+    <string name="overlay">Date Picker Overlay</string>
 </resources>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -6,6 +6,14 @@
     <string name="date_description">Select Date</string>
     <string name="day_description">Select Day</string>
     <string name="hour_description">Select Hour</string>
-    <string name="minute_description">Select Minutes</string>
-    <string name="am_pm_description">Select AM/PM</string>
+    <string name="minutes_description">Select Minutes</string>
+    <string name="ampm_description">Select AM/PM</string>
+    <string name="selected_year_description">Selected Year</string>
+    <string name="selected_month_description">Selected Month</string>
+    <string name="selected_date_description">Selected Date</string>
+    <string name="selected_day_description">Selected Day</string>
+    <string name="selected_hour_description">Selected Hour</string>
+    <string name="selected_minutes_description">Selected Minutes</string>
+    <string name="selected_ampm_description">Selected AM/PM</string>
+    <string name="selected_value_description">Value is</string>
 </resources>


### PR DESCRIPTION
The PR is aimed to provide accessibility support for the android picker. When the screen reader (**Android Phone Settings->Accessibility features->Accessibility->ScreenReader-> Toggle switch to on state**) for android devices is focussed on date picker the current version of date picker does not read any thing on the screen. This PR has now fixed this issue.

- When ScreenReader is now focussed on the Different Wheels, it will now read the content description for each wheel like select year, select day, select month, etc
- When user scrolls and selects any date, it will now read the content description as "**Selected {Wheel}, Value is 2nd December 2021 Time is 09 Hour: 30 Minutes**"
- Provided Localised support for above strings that will be read by the screen reader when the locale prop is set from react-native