### PR TITLE
Translate a11y strings to Norwegian

### DIFF
--- a/android/src/main/res/values-nb/strings.xml
+++ b/android/src/main/res/values-nb/strings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="overlay">Datovelger</string>
+    <string name="year_description">Velg år</string>
+    <string name="month_description">Velg måned</string>
+    <string name="date_description">Velg dato</string>
+    <string name="day_description">Velg dag</string>
+    <string name="hour_description">Velg time</string>
+    <string name="minutes_description">Velg minutter</string>
+    <string name="ampm_description">Velg am/pm</string>
+    <string name="selected_year_description">Valgt år</string>
+    <string name="selected_month_description">Valgt måned</string>
+    <string name="selected_date_description">Valgt dato</string>
+    <string name="selected_day_description">Valgt dag</string>
+    <string name="selected_hour_description">Valgt time</string>
+    <string name="selected_minutes_description">Valgte minutter</string>
+    <string name="selected_ampm_description">Valgt am/pm</string>
+    <string name="selected_value_description">Verdien er</string>
+    <string name="time_tag">Tiden er</string>
+    <string name="hour_tag">Time</string>
+    <string name="minutes_tag">Minutter</string>
+</resources>

--- a/android/src/main/res/values-nn/strings.xml
+++ b/android/src/main/res/values-nn/strings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="overlay">Datoveljar</string>
+    <string name="year_description">Vel år</string>
+    <string name="month_description">Vel månad</string>
+    <string name="date_description">Vel dato</string>
+    <string name="day_description">Vel dag</string>
+    <string name="hour_description">Vel time</string>
+    <string name="minutes_description">Vel minutt</string>
+    <string name="ampm_description">Vel am/pm</string>
+    <string name="selected_year_description">Vald år</string>
+    <string name="selected_month_description">Vald månad</string>
+    <string name="selected_date_description">Vald dato</string>
+    <string name="selected_day_description">Vald dag</string>
+    <string name="selected_hour_description">Vald time</string>
+    <string name="selected_minutes_description">Valde minutt</string>
+    <string name="selected_ampm_description">Vald am/pm</string>
+    <string name="selected_value_description">Verdien er</string>
+    <string name="time_tag">Tida er</string>
+    <string name="hour_tag">Time</string>
+    <string name="minutes_tag">Minutt</string>
+</resources>

--- a/android/src/main/res/values-no/strings.xml
+++ b/android/src/main/res/values-no/strings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="overlay">Datovelger</string>
+    <string name="year_description">Velg år</string>
+    <string name="month_description">Velg måned</string>
+    <string name="date_description">Velg dato</string>
+    <string name="day_description">Velg dag</string>
+    <string name="hour_description">Velg time</string>
+    <string name="minutes_description">Velg minutter</string>
+    <string name="ampm_description">Velg am/pm</string>
+    <string name="selected_year_description">Valgt år</string>
+    <string name="selected_month_description">Valgt måned</string>
+    <string name="selected_date_description">Valgt dato</string>
+    <string name="selected_day_description">Valgt dag</string>
+    <string name="selected_hour_description">Valgt time</string>
+    <string name="selected_minutes_description">Valgte minutter</string>
+    <string name="selected_ampm_description">Valgt am/pm</string>
+    <string name="selected_value_description">Verdien er</string>
+    <string name="time_tag">Tiden er</string>
+    <string name="hour_tag">Time</string>
+    <string name="minutes_tag">Minutter</string>
+</resources>


### PR DESCRIPTION
Localized strings for Android for the Norwegian written languages bokmål (no, nb) and nynorsk (nn).

Tested on device by installing from our own git branch.