### PR TITLE
RTL support

### DIFF
--- a/android/src/main/java/com/henninghall/date_picker/DerivedData.java
+++ b/android/src/main/java/com/henninghall/date_picker/DerivedData.java
@@ -63,6 +63,13 @@ public class DerivedData {
         String dateTimePattern = dateTimePatternOld.replaceAll("\\('(.+?)'\\)","\\${$1}")
                 .replaceAll("'.+?'","")
                 .replaceAll("\\$\\{(.+?)\\}","('$1')");
+        
+        boolean isRTL = TextUtils.getLayoutDirectionFromLocale(Locale.getDefault()) == View.LAYOUT_DIRECTION_RTL;
+
+        if (isRTL) {
+            String rtlDateTimePattern = dateTimePattern.replaceAll("(.+\\s)([Hh]{1,2}):(mm)(:.+)","$1$3:$2$4");
+            dateTimePattern = rtlDateTimePattern;
+        }
         ArrayList<WheelType> unorderedTypes = new ArrayList(Arrays.asList(WheelType.values()));
         ArrayList<WheelType> orderedWheels = new ArrayList<>();
 

--- a/android/src/main/java/com/henninghall/date_picker/DerivedData.java
+++ b/android/src/main/java/com/henninghall/date_picker/DerivedData.java
@@ -11,6 +11,12 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import java.util.Locale;
+
+import android.text.TextUtils;
+import android.view.View;
+
+
 import static com.henninghall.date_picker.models.Is24HourSource.*;
 
 public class DerivedData {


### PR DESCRIPTION
This is a quick and dirty RTL support, it uses the current date time pattern parsing but changing the order with Regex to make the items on screen appear right.

Some explanations:
The original LTR wheel in case of d HH/h mm will look like - day | hour | minute
When switching to RTL without any conversions it will look like - minute | hour | day (Reading from right to left, the day is in place but since we're still reading the clock like the rest of the world where the hours are preceding the minutes, instead of like this: 23:59 we're seeing something like this: 59:23)
After the conversion it will look like - hour | minute | day (resulting with 23:59 instead of any other funky representation).

Related to bug #339 , solved with a lot of assistance from the magnificent @guytepper