### PR TITLE
fix: remove app_name string

### DIFF
--- a/android/src/main/res/values-he/strings.xml
+++ b/android/src/main/res/values-he/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">react-native-date-picker</string>
     <string name="overlay">בוחר תאריכים צף</string>
     <string name="year_description">בחירת שנה</string>
     <string name="month_description">בחירת חודש</string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">react-native-date-picker</string>
     <string name="overlay">Date Picker Overlay</string>
     <string name="year_description">Select Year</string>
     <string name="month_description">Select Month</string>


### PR DESCRIPTION
fixes https://github.com/henninghall/react-native-date-picker/issues/342