### PR TITLE
Fix: Two-finger scroll issue when TalkBack is active

### DIFF
--- a/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
@@ -4,20 +4,33 @@ import android.content.Context;
 import android.graphics.Color;
 import android.util.AttributeSet;
 import android.view.View;
+import android.view.MotionEvent;
+import android.view.accessibility.AccessibilityManager;
+import android.content.Context;
 import cn.carbswang.android.numberpickerview.library.NumberPickerView;
 
 public class IosClone extends NumberPickerView implements Picker {
 
+    private AccessibilityManager mAccessibilityManager;
+
+    private void initAccessibilityManager(Context context) {
+        Context appContext = context.getApplicationContext();
+        mAccessibilityManager = (AccessibilityManager) appContext.getSystemService(Context.ACCESSIBILITY_SERVICE);
+    }
+
     public IosClone(Context context) {
         super(context);
+        initAccessibilityManager(context);
     }
 
     public IosClone(Context context, AttributeSet attrs) {
         super(context, attrs);
+        initAccessibilityManager(context);
     }
 
     public IosClone(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
+        initAccessibilityManager(context);
     }
 
     @Override
@@ -57,5 +70,30 @@ public class IosClone extends NumberPickerView implements Picker {
     @Override
     public boolean isSpinning() {
         return super.isScrolling();
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        /*
+            When TalkBack is active, user can use one finger to explore the screen
+            and set focus to elements. Then user can proceed to use second finger
+            to scroll contents of focused element.
+            When there's multiple pickers next to each other horizontally,
+            it's easy to accidentally scroll more than one picker at a time.
+            Following code aims to fix this issue.
+        */
+
+        // If TalkBack isn't active, always proceed without suppressing touch events
+        if (!mAccessibilityManager.isTouchExplorationEnabled()) {
+            super.onTouchEvent(event);
+            return true;
+        }
+
+        if (this.isAccessibilityFocused()) {
+            super.onTouchEvent(event);
+            return true;
+        }
+
+        return false;
     }
 }

--- a/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
@@ -2,12 +2,9 @@ package com.henninghall.date_picker.pickers;
 
 import android.content.Context;
 import android.graphics.Color;
-import android.os.Build;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.MotionEvent;
-import android.view.accessibility.AccessibilityManager;
-import android.content.Context;
 
 import com.henninghall.date_picker.ui.Accessibility;
 

--- a/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
@@ -2,35 +2,29 @@ package com.henninghall.date_picker.pickers;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.os.Build;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.MotionEvent;
 import android.view.accessibility.AccessibilityManager;
 import android.content.Context;
+
+import com.henninghall.date_picker.ui.Accessibility;
+
 import cn.carbswang.android.numberpickerview.library.NumberPickerView;
 
 public class IosClone extends NumberPickerView implements Picker {
 
-    private AccessibilityManager mAccessibilityManager;
-
-    private void initAccessibilityManager(Context context) {
-        Context appContext = context.getApplicationContext();
-        mAccessibilityManager = (AccessibilityManager) appContext.getSystemService(Context.ACCESSIBILITY_SERVICE);
-    }
-
     public IosClone(Context context) {
         super(context);
-        initAccessibilityManager(context);
     }
 
     public IosClone(Context context, AttributeSet attrs) {
         super(context, attrs);
-        initAccessibilityManager(context);
     }
 
     public IosClone(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-        initAccessibilityManager(context);
     }
 
     @Override
@@ -74,26 +68,10 @@ public class IosClone extends NumberPickerView implements Picker {
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
-        /*
-            When TalkBack is active, user can use one finger to explore the screen
-            and set focus to elements. Then user can proceed to use second finger
-            to scroll contents of focused element.
-            When there's multiple pickers next to each other horizontally,
-            it's easy to accidentally scroll more than one picker at a time.
-            Following code aims to fix this issue.
-        */
-
-        // If TalkBack isn't active, always proceed without suppressing touch events
-        if (!mAccessibilityManager.isTouchExplorationEnabled()) {
+        if(Accessibility.shouldAllowScroll(this)){
             super.onTouchEvent(event);
             return true;
         }
-
-        if (this.isAccessibilityFocused()) {
-            super.onTouchEvent(event);
-            return true;
-        }
-
         return false;
     }
 }

--- a/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
@@ -1,8 +1,12 @@
 package com.henninghall.date_picker.ui;
 
+import android.content.Context;
+import android.os.Build;
 import android.view.View;
 import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityManager;
 
+import com.henninghall.date_picker.DatePickerManager;
 import com.henninghall.date_picker.State;
 import com.henninghall.date_picker.Utils;
 import com.henninghall.date_picker.wheelFunctions.WheelFunction;
@@ -11,6 +15,30 @@ import com.henninghall.date_picker.wheels.Wheel;
 import java.util.Locale;
 
 public class Accessibility {
+
+    private final static AccessibilityManager systemManager =
+            (AccessibilityManager) DatePickerManager.context
+                    .getApplicationContext()
+                    .getSystemService(Context.ACCESSIBILITY_SERVICE);
+
+    /**
+      When TalkBack is active, user can use one finger to explore the screen
+      and set focus to elements. Then user can proceed to use second finger
+      to scroll contents of focused element.
+      When there's multiple pickers next to each other horizontally,
+      it's easy to accidentally scroll more than one picker at a time.
+      Following code aims to fix this issue.
+    */
+    public static boolean shouldAllowScroll(View view){
+        // If TalkBack isn't active, always proceed without suppressing touch events
+        if (!systemManager.isTouchExplorationEnabled()) {
+            return true;
+        }
+        if (Build.VERSION.SDK_INT >= 21) {
+            return view.isAccessibilityFocused();
+        }
+        return false;
+    }
 
     public static class SetAccessibilityDelegate implements WheelFunction {
 


### PR DESCRIPTION
My best effort on fixing #336 

- Does it by disabling onTouchEvent for all wheels but the one having accessibility focus (IosClone)
- Shouldn't affect anything when TalkBack isn't active

**BEFORE FIX**
![fail](https://user-images.githubusercontent.com/3703618/130803512-4f22b0c6-1ab2-418d-bb8d-109e236d81bf.gif)

**AFTER FIX**
![success](https://user-images.githubusercontent.com/3703618/130803493-2dbd7c6d-b0f7-49e6-8429-e7f04cc8dc40.gif)



