### PR TITLE
fix: talkback read display value on scroll value change

### DIFF
--- a/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
@@ -6,9 +6,9 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.view.MotionEvent;
 
-import com.henninghall.date_picker.ui.Accessibility;
-
 import cn.carbswang.android.numberpickerview.library.NumberPickerView;
+
+import com.henninghall.date_picker.ui.Accessibility;
 
 public class IosClone extends NumberPickerView implements Picker {
     private Picker.OnValueChangeListenerInScrolling mOnValueChangeListenerInScrolling;
@@ -17,8 +17,10 @@ public class IosClone extends NumberPickerView implements Picker {
         final Picker self = this;
         super.setOnValueChangeListenerInScrolling(new NumberPickerView.OnValueChangeListenerInScrolling() {
             @Override
+
             public void onValueChangeInScrolling(NumberPickerView picker, int oldVal, int newVal) {
-                Accessibility.announce(String.valueOf(newVal));
+                Accessibility.announceNumberPickerViewValue(picker, newVal);
+
                 if (mOnValueChangeListenerInScrolling != null) {
                     mOnValueChangeListenerInScrolling.onValueChangeInScrolling(self, oldVal, newVal);
                 }

--- a/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
@@ -11,17 +11,34 @@ import com.henninghall.date_picker.ui.Accessibility;
 import cn.carbswang.android.numberpickerview.library.NumberPickerView;
 
 public class IosClone extends NumberPickerView implements Picker {
+    private Picker.OnValueChangeListenerInScrolling mOnValueChangeListenerInScrolling;
+
+    private void initSetOnValueChangeListenerInScrolling() {
+        final Picker self = this;
+        super.setOnValueChangeListenerInScrolling(new NumberPickerView.OnValueChangeListenerInScrolling() {
+            @Override
+            public void onValueChangeInScrolling(NumberPickerView picker, int oldVal, int newVal) {
+                Accessibility.announce(String.valueOf(newVal));
+                if (mOnValueChangeListenerInScrolling != null) {
+                    mOnValueChangeListenerInScrolling.onValueChangeInScrolling(self, oldVal, newVal);
+                }
+            }
+        });
+    }
 
     public IosClone(Context context) {
         super(context);
+        initSetOnValueChangeListenerInScrolling();
     }
 
     public IosClone(Context context, AttributeSet attrs) {
         super(context, attrs);
+        initSetOnValueChangeListenerInScrolling();
     }
 
     public IosClone(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
+        initSetOnValueChangeListenerInScrolling();
     }
 
     @Override
@@ -34,13 +51,7 @@ public class IosClone extends NumberPickerView implements Picker {
 
     @Override
     public void setOnValueChangeListenerInScrolling(final Picker.OnValueChangeListenerInScrolling listener) {
-        final Picker self = this;
-        super.setOnValueChangeListenerInScrolling(new NumberPickerView.OnValueChangeListenerInScrolling() {
-            @Override
-            public void onValueChangeInScrolling(NumberPickerView picker, int oldVal, int newVal) {
-                listener.onValueChangeInScrolling(self, oldVal, newVal);
-            }
-        });
+        this.mOnValueChangeListenerInScrolling = listener;
     }
 
     @Override

--- a/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
@@ -34,7 +34,7 @@ public class IosClone extends NumberPickerView implements Picker {
             @Override
 
             public void onValueChangeInScrolling(NumberPickerView picker, int oldVal, int newVal) {
-                Accessibility.announceNumberPickerViewValue(picker, newVal);
+                Accessibility.announceNumberPickerValue(picker, newVal);
 
                 if (mOnValueChangeListenerInScrolling != null) {
                     mOnValueChangeListenerInScrolling.onValueChangeInScrolling(self, oldVal, newVal);

--- a/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
@@ -13,21 +13,6 @@ import com.henninghall.date_picker.ui.Accessibility;
 public class IosClone extends NumberPickerView implements Picker {
     private Picker.OnValueChangeListenerInScrolling mOnValueChangeListenerInScrolling;
 
-    private void initSetOnValueChangeListenerInScrolling() {
-        final Picker self = this;
-        super.setOnValueChangeListenerInScrolling(new NumberPickerView.OnValueChangeListenerInScrolling() {
-            @Override
-
-            public void onValueChangeInScrolling(NumberPickerView picker, int oldVal, int newVal) {
-                Accessibility.announceNumberPickerViewValue(picker, newVal);
-
-                if (mOnValueChangeListenerInScrolling != null) {
-                    mOnValueChangeListenerInScrolling.onValueChangeInScrolling(self, oldVal, newVal);
-                }
-            }
-        });
-    }
-
     public IosClone(Context context) {
         super(context);
         initSetOnValueChangeListenerInScrolling();
@@ -41,6 +26,21 @@ public class IosClone extends NumberPickerView implements Picker {
     public IosClone(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         initSetOnValueChangeListenerInScrolling();
+    }
+
+    private void initSetOnValueChangeListenerInScrolling() {
+        final Picker self = this;
+        super.setOnValueChangeListenerInScrolling(new NumberPickerView.OnValueChangeListenerInScrolling() {
+            @Override
+
+            public void onValueChangeInScrolling(NumberPickerView picker, int oldVal, int newVal) {
+                Accessibility.announceNumberPickerViewValue(picker, newVal);
+
+                if (mOnValueChangeListenerInScrolling != null) {
+                    mOnValueChangeListenerInScrolling.onValueChangeInScrolling(self, oldVal, newVal);
+                }
+            }
+        });
     }
 
     @Override

--- a/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
@@ -85,6 +85,23 @@ public class Accessibility {
         picker.picker.getView().setContentDescription(descriptionPrefix + ", "+ descriptionPostFix + " "+ selectedDateString);
     }
 
+    /**
+     * Read a message out loud with when TalkBack is enabled
+     */
+    public static void announce(String message) {
+        if (systemManager == null || !systemManager.isEnabled()) {
+            return;
+          }
+
+          AccessibilityEvent event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_ANNOUNCEMENT);
+          event.getText().add(message);
+          systemManager.sendAccessibilityEvent(event);
+    }
+
+    public static void setContentDescription(String text, Wheel wheel) {
+        wheel.picker.getView().setContentDescription(text);
+    }
+
     private String getAccessibleTextForSelectedDate() {
         String accessibleText;
         switch(state.getMode()) {

--- a/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
@@ -5,6 +5,8 @@ import android.os.Build;
 import android.view.View;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
+import android.accessibilityservice.AccessibilityServiceInfo;
+import cn.carbswang.android.numberpickerview.library.NumberPickerView;
 
 import com.henninghall.date_picker.DatePickerManager;
 import com.henninghall.date_picker.State;
@@ -13,6 +15,8 @@ import com.henninghall.date_picker.wheelFunctions.WheelFunction;
 import com.henninghall.date_picker.wheels.Wheel;
 
 import java.util.Locale;
+import java.util.Arrays;
+import java.util.List;
 
 public class Accessibility {
 
@@ -85,11 +89,23 @@ public class Accessibility {
         picker.picker.getView().setContentDescription(descriptionPrefix + ", "+ descriptionPostFix + " "+ selectedDateString);
     }
 
+    public static boolean isSpokenFeedbackEnabled() {
+        return hasAccessibilityFeatureTypeEnabled(AccessibilityServiceInfo.FEEDBACK_SPOKEN);
+    }
+
+    private static boolean hasAccessibilityFeatureTypeEnabled(int type) {
+
+        List<AccessibilityServiceInfo> enabledServices =
+                systemManager.getEnabledAccessibilityServiceList(type);
+
+        return enabledServices != null && enabledServices.size() > 0;
+    }
+
     /**
      * Read a message out loud with when TalkBack is enabled
      */
     public static void announce(String message) {
-        if (systemManager == null || !systemManager.isEnabled()) {
+        if (systemManager == null || !isSpokenFeedbackEnabled()) {
             return;
           }
 
@@ -98,8 +114,27 @@ public class Accessibility {
           systemManager.sendAccessibilityEvent(event);
     }
 
-    public static void setContentDescription(String text, Wheel wheel) {
-        wheel.picker.getView().setContentDescription(text);
+    /**
+     * Get NumberPickerView displayed value from value.
+     */
+    private static String valueToString(NumberPickerView numberPicker, int value) {
+        final String[] displayValues = numberPicker.getDisplayedValues();
+
+        final String displayValue = displayValues[value];
+
+        if (displayValue != null) {
+            return displayValue;
+        }
+
+        return String.valueOf(value);
+    }
+
+    /**
+     * Read NumberPickerView displayed value.
+     * For TalkBack to read dates etc. correctly, make sure they are in localised format.
+     */
+    public static void announceNumberPickerViewValue(NumberPickerView numberPicker, int newValue) {
+        announce(valueToString(numberPicker, newValue));
     }
 
     private String getAccessibleTextForSelectedDate() {

--- a/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
@@ -89,10 +89,16 @@ public class Accessibility {
         picker.picker.getView().setContentDescription(descriptionPrefix + ", "+ descriptionPostFix + " "+ selectedDateString);
     }
 
+    /**
+     * Checks if the accessibility service responsible of spoken feedback is active
+     */
     public static boolean isSpokenFeedbackEnabled() {
         return hasAccessibilityFeatureTypeEnabled(AccessibilityServiceInfo.FEEDBACK_SPOKEN);
     }
 
+    /**
+     * Get a list of accessibility services currently active
+     */
     private static boolean hasAccessibilityFeatureTypeEnabled(int type) {
 
         List<AccessibilityServiceInfo> enabledServices =
@@ -102,7 +108,7 @@ public class Accessibility {
     }
 
     /**
-     * Read a message out loud with when TalkBack is enabled
+     * Read a message out loud when spoken feedback is active
      */
     public static void announce(String message) {
         if (systemManager == null || !isSpokenFeedbackEnabled()) {
@@ -115,7 +121,7 @@ public class Accessibility {
     }
 
     /**
-     * Get NumberPickerView displayed value from value.
+     * Get NumberPickerView displayValue from value.
      */
     private static String valueToString(NumberPickerView numberPicker, int value) {
         final String[] displayValues = numberPicker.getDisplayedValues();

--- a/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
@@ -123,7 +123,7 @@ public class Accessibility {
     /**
      * Get NumberPickerView displayValue from value.
      */
-    private static String valueToString(NumberPickerView numberPicker, int value) {
+    private static String numberPickerValueToDisplayedValue(NumberPickerView numberPicker, int value) {
         final String[] displayValues = numberPicker.getDisplayedValues();
 
         final String displayValue = displayValues[value];
@@ -139,8 +139,8 @@ public class Accessibility {
      * Read NumberPickerView displayed value.
      * For TalkBack to read dates etc. correctly, make sure they are in localised format.
      */
-    public static void announceNumberPickerViewValue(NumberPickerView numberPicker, int newValue) {
-        announce(valueToString(numberPicker, newValue));
+    public static void announceNumberPickerValue(NumberPickerView numberPicker, int newValue) {
+        announce(numberPickerValueToDisplayedValue(numberPicker, newValue));
     }
 
     private String getAccessibleTextForSelectedDate() {


### PR DESCRIPTION
- Accessibility for IosPicker:
   - Read changed display value out loud when scrolling and spoken feed back is enabled 
   - TalkBack can detect standard date formats and parse them into very nice spoken version. So just reading display value should  be enough

**Changes**
- IosPicker: 
   - OnValueChangeListenerInScrolling is stored in a variable, so we can add default functionality regardless of the listener 
- Accessibility:
   - Added static functions for announcing things via spoken feedback / TalkBack   