### PR TITLE
fix: setTextColor should always run on superclass

### DIFF
--- a/android/src/main/java/com/henninghall/date_picker/pickers/AndroidNative.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/AndroidNative.java
@@ -54,7 +54,7 @@ public class AndroidNative extends NumberPicker implements Picker {
         int color = Color.parseColor(stringColor);
 
         if (Build.VERSION.SDK_INT >= 29) {
-            setTextColor(color);
+            super.setTextColor(color);
             return;
         }
 


### PR DESCRIPTION
probably fixes https://github.com/henninghall/react-native-date-picker/issues/368