### PR TITLE
feat: improved spoken feedback

### DIFF
--- a/android/src/main/java/com/henninghall/date_picker/LocaleUtils.java
+++ b/android/src/main/java/com/henninghall/date_picker/LocaleUtils.java
@@ -67,28 +67,33 @@ public class LocaleUtils {
     }
 
     public static String getLocaleStringResource(Locale requestedLocale, int resourceId, Context context) {
-        String result;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) { // use latest api
-            Configuration config = new Configuration(context.getResources().getConfiguration());
-            config.setLocale(requestedLocale);
-            result = context.createConfigurationContext(config).getText(resourceId).toString();
+        try {
+            String result;
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) { // use latest api
+                Configuration config = new Configuration(context.getResources().getConfiguration());
+                config.setLocale(requestedLocale);
+                result = context.createConfigurationContext(config).getText(resourceId).toString();
+            }
+            else { // support older android versions
+                Resources resources = context.getResources();
+                Configuration conf = resources.getConfiguration();
+                Locale savedLocale = conf.locale;
+                conf.locale = requestedLocale;
+                resources.updateConfiguration(conf, null);
+
+                // retrieve resources from desired locale
+                result = resources.getString(resourceId);
+
+                // restore original locale
+                conf.locale = savedLocale;
+                resources.updateConfiguration(conf, null);
+            }
+
+            return result;
+        } catch (Exception e) {
+            return ""; // Return empty string when no resource was found
         }
-        else { // support older android versions
-            Resources resources = context.getResources();
-            Configuration conf = resources.getConfiguration();
-            Locale savedLocale = conf.locale;
-            conf.locale = requestedLocale;
-            resources.updateConfiguration(conf, null);
-
-            // retrieve resources from desired locale
-            result = resources.getString(resourceId);
-
-            // restore original locale
-            conf.locale = savedLocale;
-            resources.updateConfiguration(conf, null);
-        }
-
-        return result;
     }
 
 }

--- a/android/src/main/java/com/henninghall/date_picker/LocaleUtils.java
+++ b/android/src/main/java/com/henninghall/date_picker/LocaleUtils.java
@@ -92,7 +92,7 @@ public class LocaleUtils {
 
             return result;
         } catch (Exception e) {
-            return ""; // Return empty string when no resource was found
+            return ""; // Eat the error and return empty string when no resource was found
         }
     }
 

--- a/android/src/main/java/com/henninghall/date_picker/PickerView.java
+++ b/android/src/main/java/com/henninghall/date_picker/PickerView.java
@@ -80,9 +80,9 @@ public class PickerView extends RelativeLayout {
             uiManager.updateDisplayValues();
         }
 
-        if (didUpdate(ModeProp.name, LocaleProp.name)) {
-            uiManager.updateAccessibilityValues();
-        }
+        // if (didUpdate(ModeProp.name, LocaleProp.name)) {
+        //     uiManager.updateAccessibilityValues();
+        // }
 
         uiManager.setWheelsToDate();
 

--- a/android/src/main/java/com/henninghall/date_picker/PickerView.java
+++ b/android/src/main/java/com/henninghall/date_picker/PickerView.java
@@ -20,6 +20,8 @@ import com.henninghall.date_picker.props.LocaleProp;
 import com.henninghall.date_picker.props.ModeProp;
 import com.henninghall.date_picker.props.TextColorProp;
 import com.henninghall.date_picker.ui.UIManager;
+import com.henninghall.date_picker.ui.Accessibility;
+
 import java.util.ArrayList;
 
 public class PickerView extends RelativeLayout {
@@ -80,9 +82,9 @@ public class PickerView extends RelativeLayout {
             uiManager.updateDisplayValues();
         }
 
-        // if (didUpdate(ModeProp.name, LocaleProp.name)) {
-        //     uiManager.updateAccessibilityValues();
-        // }
+        if (didUpdate(LocaleProp.name)) {
+            Accessibility.setLocale(state.getLocale());
+        }
 
         uiManager.setWheelsToDate();
 

--- a/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
@@ -34,7 +34,7 @@ public class IosClone extends NumberPickerView implements Picker {
             @Override
 
             public void onValueChangeInScrolling(NumberPickerView picker, int oldVal, int newVal) {
-                Accessibility.announceNumberPickerValue(picker, newVal);
+                Accessibility.announcePickerValue(self, newVal);
 
                 if (mOnValueChangeListenerInScrolling != null) {
                     mOnValueChangeListenerInScrolling.onValueChangeInScrolling(self, oldVal, newVal);

--- a/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
@@ -2,13 +2,17 @@ package com.henninghall.date_picker.pickers;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.os.Build;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.MotionEvent;
+import android.view.accessibility.AccessibilityNodeInfo;
+import android.view.accessibility.AccessibilityNodeInfo.AccessibilityAction;
 
 import cn.carbswang.android.numberpickerview.library.NumberPickerView;
 
 import com.henninghall.date_picker.ui.Accessibility;
+
 
 public class IosClone extends NumberPickerView implements Picker {
     private Picker.OnValueChangeListenerInScrolling mOnValueChangeListenerInScrolling;
@@ -95,5 +99,11 @@ public class IosClone extends NumberPickerView implements Picker {
             return true;
         }
         return false;
+    }
+
+    @Override
+    public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
+        super.onInitializeAccessibilityNodeInfo(info);
+        Accessibility.setRoleToSlider(info);
     }
 }

--- a/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
@@ -30,6 +30,9 @@ public class IosClone extends NumberPickerView implements Picker {
 
     private void initSetOnValueChangeListenerInScrolling() {
         final Picker self = this;
+
+        Accessibility.startAccessibilityDelegate(self, java.util.Locale.ENGLISH);
+
         super.setOnValueChangeListenerInScrolling(new NumberPickerView.OnValueChangeListenerInScrolling() {
             @Override
 

--- a/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
@@ -46,9 +46,10 @@ public class IosClone extends NumberPickerView implements Picker {
 
         super.setOnValueChangeListenerInScrolling(new NumberPickerView.OnValueChangeListenerInScrolling() {
             @Override
-
             public void onValueChangeInScrolling(NumberPickerView picker, int oldVal, int newVal) {
-                Accessibility.sendValueChangedEvent(self, newVal);
+                if (oldVal != newVal) {
+                    Accessibility.sendValueChangedEvent(self, newVal);
+                }
 
                 if (mOnValueChangeListenerInScrolling != null) {
                     mOnValueChangeListenerInScrolling.onValueChangeInScrolling(self, oldVal, newVal);

--- a/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
@@ -34,13 +34,11 @@ public class IosClone extends NumberPickerView implements Picker {
     }
 
     private void initAccessibility() {
-        Accessibility.startAccessibilityDelegate(this, java.util.Locale.ENGLISH);
+        Accessibility.startAccessibilityDelegate(this);
     }
 
     private void initSetOnValueChangeListenerInScrolling() {
         final Picker self = this;
-
-        Accessibility.startAccessibilityDelegate(self, java.util.Locale.ENGLISH);
 
         super.setOnValueChangeListenerInScrolling(new NumberPickerView.OnValueChangeListenerInScrolling() {
             @Override
@@ -74,7 +72,7 @@ public class IosClone extends NumberPickerView implements Picker {
         super.setOnValueChangedListener(new NumberPickerView.OnValueChangeListener() {
             @Override
             public void onValueChange(NumberPickerView picker, int oldVal, int newVal) {
-                Accessibility.announceSelectedPickerValue(self, newVal, java.util.Locale.ENGLISH);
+                Accessibility.announceSelectedPickerValue(self, newVal);
                 listener.onValueChange();
             }
         });

--- a/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
@@ -58,9 +58,11 @@ public class IosClone extends NumberPickerView implements Picker {
 
     @Override
     public void setOnValueChangedListener(final Picker.OnValueChangeListener listener) {
+        final Picker self = this;
         super.setOnValueChangedListener(new NumberPickerView.OnValueChangeListener() {
             @Override
             public void onValueChange(NumberPickerView picker, int oldVal, int newVal) {
+                Accessibility.announceSelectedPickerValue(self, newVal, java.util.Locale.ENGLISH);
                 listener.onValueChange();
             }
         });

--- a/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
@@ -48,7 +48,7 @@ public class IosClone extends NumberPickerView implements Picker {
             @Override
 
             public void onValueChangeInScrolling(NumberPickerView picker, int oldVal, int newVal) {
-                Accessibility.announcePickerValue(self, newVal);
+                Accessibility.sendValueChangedEvent(self, newVal);
 
                 if (mOnValueChangeListenerInScrolling != null) {
                     mOnValueChangeListenerInScrolling.onValueChangeInScrolling(self, oldVal, newVal);
@@ -72,11 +72,9 @@ public class IosClone extends NumberPickerView implements Picker {
 
     @Override
     public void setOnValueChangedListener(final Picker.OnValueChangeListener listener) {
-        final Picker self = this;
         super.setOnValueChangedListener(new NumberPickerView.OnValueChangeListener() {
             @Override
             public void onValueChange(NumberPickerView picker, int oldVal, int newVal) {
-                Accessibility.announceSelectedPickerValue(self, newVal);
                 listener.onValueChange();
             }
         });

--- a/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
@@ -47,9 +47,7 @@ public class IosClone extends NumberPickerView implements Picker {
         super.setOnValueChangeListenerInScrolling(new NumberPickerView.OnValueChangeListenerInScrolling() {
             @Override
             public void onValueChangeInScrolling(NumberPickerView picker, int oldVal, int newVal) {
-                if (oldVal != newVal) {
-                    Accessibility.sendValueChangedEvent(self, newVal);
-                }
+                Accessibility.sendValueChangedEvent(self, newVal);
 
                 if (mOnValueChangeListenerInScrolling != null) {
                     mOnValueChangeListenerInScrolling.onValueChangeInScrolling(self, oldVal, newVal);
@@ -94,8 +92,7 @@ public class IosClone extends NumberPickerView implements Picker {
     @Override
     public boolean onTouchEvent(MotionEvent event) {
         if(Accessibility.shouldAllowScroll(this)){
-            super.onTouchEvent(event);
-            return true;
+            return super.onTouchEvent(event);
         }
         return false;
     }
@@ -103,6 +100,7 @@ public class IosClone extends NumberPickerView implements Picker {
     @Override
     public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
         super.onInitializeAccessibilityNodeInfo(info);
-        Accessibility.setRoleToSlider(info);
+        // Set the accessibility properties of this view
+        Accessibility.setRoleToSlider(this, info);
     }
 }

--- a/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/IosClone.java
@@ -15,17 +15,26 @@ public class IosClone extends NumberPickerView implements Picker {
 
     public IosClone(Context context) {
         super(context);
-        initSetOnValueChangeListenerInScrolling();
+        init();
     }
 
     public IosClone(Context context, AttributeSet attrs) {
         super(context, attrs);
-        initSetOnValueChangeListenerInScrolling();
+        init();
     }
 
     public IosClone(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
+        init();
+    }
+
+    private void init() {
+        initAccessibility();
         initSetOnValueChangeListenerInScrolling();
+    }
+
+    private void initAccessibility() {
+        Accessibility.startAccessibilityDelegate(this, java.util.Locale.ENGLISH);
     }
 
     private void initSetOnValueChangeListenerInScrolling() {

--- a/android/src/main/java/com/henninghall/date_picker/pickers/Picker.java
+++ b/android/src/main/java/com/henninghall/date_picker/pickers/Picker.java
@@ -12,6 +12,7 @@ public interface Picker {
     int getMaxValue();
     boolean getWrapSelectorWheel();
     void setDisplayedValues(String[] value);
+    String[] getDisplayedValues();
     int getValue();
     void setValue(int value);
     void setTextColor(String value);

--- a/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
@@ -17,6 +17,8 @@ import java.util.List;
 
 import android.view.accessibility.AccessibilityNodeInfo;
 
+import android.util.Log;
+
 public class Accessibility {
     private final static AccessibilityManager systemManager =
             (AccessibilityManager) DatePickerPackage.context
@@ -64,6 +66,7 @@ public class Accessibility {
                     @Override
                     public void onPopulateAccessibilityEvent(View host, AccessibilityEvent event) {
                         super.onPopulateAccessibilityEvent(host, event);
+                        Log.d("FOO", String.valueOf(event.getEventType()));
                         if (event.getEventType() == AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED) {
                             // Screen reader reads the content description when focused on each picker wheel
                             Accessibility.updateContentDescription(fPicker);
@@ -75,14 +78,18 @@ public class Accessibility {
                         int currentValue;
                         switch (action) {
                             case AccessibilityNodeInfo.ACTION_SCROLL_FORWARD:
-                                // Increase value when pressing hardware volume up
-                                currentValue = fPicker.getValue();
-                                fPicker.smoothScrollToValue(currentValue - 1);
+                                if (!fPicker.isSpinning()) {
+                                    // Increase value when pressing hardware volume up (or scrolling by other means)
+                                    currentValue = fPicker.getValue();
+                                    fPicker.smoothScrollToValue(currentValue - 1);
+                                }
                                 break;
                             case AccessibilityNodeInfo.ACTION_SCROLL_BACKWARD:
-                                // Decrease value when pressing hardware volume down
-                                currentValue = fPicker.getValue();
-                                fPicker.smoothScrollToValue(currentValue + 1);
+                                if (!fPicker.isSpinning()) {
+                                    // Decrease value when pressing hardware volume down (or scrolling by other means)
+                                    currentValue = fPicker.getValue();
+                                    fPicker.smoothScrollToValue(currentValue + 1);
+                                }
                                 break;
                         }
 

--- a/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
@@ -22,14 +22,14 @@ public class Accessibility {
                     .getApplicationContext()
                     .getSystemService(Context.ACCESSIBILITY_SERVICE);
 
-    private static Locale locale = Locale.getDefault();
+    private static Locale mLocale = Locale.getDefault();
 
     public static void setLocale(Locale nextLocale) {
-        this.locale = nextLocale;
+        mLocale = nextLocale;
     }
 
     public static Locale getLocale() {
-        return this.locale;
+        return mLocale;
     }
 
     /**
@@ -65,7 +65,7 @@ public class Accessibility {
                         super.onPopulateAccessibilityEvent(host, event);
                         if (event.getEventType() == AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED) {
                             // Screen reader reads the content description when focused on each picker wheel
-                            Accessibility.updateContentDescription(fPicker, Accessibility.getLocale());
+                            Accessibility.updateContentDescription(fPicker);
                         }
                     }
                 }
@@ -129,7 +129,7 @@ public class Accessibility {
     public static void announceSelectedPickerValue(Picker picker, int newValue) {
         String tagName = picker.getView().getTag().toString();
         String selectedDisplayValue = pickerValueToDisplayedValue(picker, newValue);
-        String label = getSelectedContentDescriptionLabel(tagName, Accessibility.getLocale());
+        String label = getSelectedContentDescriptionLabel(tagName);
         announce(label + ": " + selectedDisplayValue);
     }
 
@@ -149,13 +149,13 @@ public class Accessibility {
         String tagName = picker.getView().getTag().toString();
         int currentValue = picker.getValue();
         String currentDisplayValue = pickerValueToDisplayedValue(picker, currentValue);
-        String label = getContentDescriptionLabel(tagName, Accessibility.getLocale());
+        String label = getContentDescriptionLabel(tagName);
 
         return currentDisplayValue + ", " + label;
     }
 
     public static void updateContentDescription(Picker picker){
-        String nextContentDescription = getContentDescription(picker, Accessibility.getLocale());
+        String nextContentDescription = getContentDescription(picker);
         picker.getView().setContentDescription(nextContentDescription);
     }
 }

--- a/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
@@ -6,19 +6,18 @@ import android.view.View;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
 import android.accessibilityservice.AccessibilityServiceInfo;
-import cn.carbswang.android.numberpickerview.library.NumberPickerView;
 
 import com.henninghall.date_picker.DatePickerPackage;
 import com.henninghall.date_picker.State;
 import com.henninghall.date_picker.Utils;
 import com.henninghall.date_picker.wheelFunctions.WheelFunction;
 import com.henninghall.date_picker.wheels.Wheel;
+import com.henninghall.date_picker.pickers.Picker;
 
 import java.util.Locale;
 import java.util.List;
 
 public class Accessibility {
-
     private final static AccessibilityManager systemManager =
             (AccessibilityManager) DatePickerPackage.context
                     .getApplicationContext()
@@ -120,10 +119,10 @@ public class Accessibility {
     }
 
     /**
-     * Get NumberPickerView displayValue from value.
+     * Get Picker displayValue from value.
      */
-    private static String numberPickerValueToDisplayedValue(NumberPickerView numberPicker, int value) {
-        final String[] displayValues = numberPicker.getDisplayedValues();
+    private static String pickerValueToDisplayedValue(Picker picker, int value) {
+        final String[] displayValues = picker.getDisplayedValues();
 
         final String displayValue = displayValues[value];
 
@@ -135,11 +134,31 @@ public class Accessibility {
     }
 
     /**
-     * Read NumberPickerView displayed value.
+     * Read Picker displayed value.
      * For TalkBack to read dates etc. correctly, make sure they are in localised format.
      */
-    public static void announceNumberPickerValue(NumberPickerView numberPicker, int newValue) {
-        announce(numberPickerValueToDisplayedValue(numberPicker, newValue));
+    public static void announcePickerValue(Picker  picker, int newValue) {
+        announce(pickerValueToDisplayedValue(picker, newValue));
+    }
+
+    private static String getContentDescriptionLabel(String tagName, Locale locale) {
+        // TODO: create static class property locale used here
+        // Ex add private final static string locale with set
+        return Utils.getLocalisedStringFromResources(locale, "selected_" + tagName + "_description");
+    }
+
+    public static String getContentDescription(Picker picker, Locale locale) {
+        final String tagName = picker.getView().getTag().toString();
+        final int currentValue = picker.getValue();
+        final String currentDisplayValue = pickerValueToDisplayedValue(picker, currentValue);
+        final String label = getContentDescriptionLabel(tagName, locale); // java.util.Locale.ENGLISH
+
+        return currentDisplayValue + ", " + label;
+    }
+
+    public static void updateContentDescription(Wheel wheel, State state){
+        final String nextContentDescription = getContentDescription(wheel.picker, state.getLocale());
+        wheel.picker.getView().setContentDescription(nextContentDescription);
     }
 
     private String getAccessibleTextForSelectedDate() {

--- a/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
@@ -52,17 +52,17 @@ public class Accessibility {
 
         @Override
         public void apply(Wheel wheel) {
+            final Picker picker = wheel.picker;
             final View view = wheel.picker.getView();
+
             view.setAccessibilityDelegate(
                     new View.AccessibilityDelegate(){
                         @Override
                         public void onPopulateAccessibilityEvent(View host, AccessibilityEvent event) {
                             super.onPopulateAccessibilityEvent(host, event);
                             if (event.getEventType() == AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED) {
-                                String resourceKey = view.getTag().toString()+"_description";
-                                String localeTag =  Utils.getLocalisedStringFromResources(locale, resourceKey);
                                 // Screen reader reads the content description when focused on each picker wheel
-                                view.setContentDescription(localeTag);
+                                Accessibility.updateContentDescription(picker, locale);
                             }
                         }
                     }
@@ -78,6 +78,9 @@ public class Accessibility {
         this.wheels = wheels;
     }
 
+    /**
+     * DEL
+     */
     public void update(Wheel picker){
         String tagName = picker.picker.getView().getTag().toString();
         String selectedDateString = getAccessibleTextForSelectedDate();
@@ -137,11 +140,24 @@ public class Accessibility {
      * Read Picker displayed value.
      * For TalkBack to read dates etc. correctly, make sure they are in localised format.
      */
-    public static void announcePickerValue(Picker  picker, int newValue) {
+    public static void announcePickerValue(Picker picker, int newValue) {
         announce(pickerValueToDisplayedValue(picker, newValue));
     }
 
+    public static void announceSelectedPickerValue(Picker picker, int newValue, Locale locale) {
+        final String tagName = picker.getView().getTag().toString();
+        final String selectedDisplayValue = pickerValueToDisplayedValue(picker, newValue);
+        final String label = getSelectedContentDescriptionLabel(tagName, locale);
+        announce(label + ": " + selectedDisplayValue);
+    }
+
     private static String getContentDescriptionLabel(String tagName, Locale locale) {
+        // TODO: create static class property locale used here
+        // Ex add private final static string locale with set
+        return Utils.getLocalisedStringFromResources(locale, tagName + "_description");
+    }
+
+    private static String getSelectedContentDescriptionLabel(String tagName, Locale locale) {
         // TODO: create static class property locale used here
         // Ex add private final static string locale with set
         return Utils.getLocalisedStringFromResources(locale, "selected_" + tagName + "_description");
@@ -151,14 +167,14 @@ public class Accessibility {
         final String tagName = picker.getView().getTag().toString();
         final int currentValue = picker.getValue();
         final String currentDisplayValue = pickerValueToDisplayedValue(picker, currentValue);
-        final String label = getContentDescriptionLabel(tagName, locale); // java.util.Locale.ENGLISH
+        final String label = getContentDescriptionLabel(tagName, locale);
 
         return currentDisplayValue + ", " + label;
     }
 
-    public static void updateContentDescription(Wheel wheel, State state){
-        final String nextContentDescription = getContentDescription(wheel.picker, state.getLocale());
-        wheel.picker.getView().setContentDescription(nextContentDescription);
+    public static void updateContentDescription(Picker picker, Locale locale){
+        final String nextContentDescription = getContentDescription(picker, locale);
+        picker.getView().setContentDescription(nextContentDescription);
     }
 
     private String getAccessibleTextForSelectedDate() {

--- a/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
@@ -24,7 +24,7 @@ public class Accessibility {
 
     private static Locale locale = Locale.getDefault();
 
-    public static setLocale(Locale nextLocale) {
+    public static void setLocale(Locale nextLocale) {
         this.locale = nextLocale;
     }
 

--- a/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
@@ -42,6 +42,25 @@ public class Accessibility {
         return false;
     }
 
+    public static void startAccessibilityDelegate(Picker picker, Locale locale) {
+        final Picker fPicker = picker;
+        final Locale fLocale =locale;
+        final View view = picker.getView();
+
+        view.setAccessibilityDelegate(
+                new View.AccessibilityDelegate(){
+                    @Override
+                    public void onPopulateAccessibilityEvent(View host, AccessibilityEvent event) {
+                        super.onPopulateAccessibilityEvent(host, event);
+                        if (event.getEventType() == AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED) {
+                            // Screen reader reads the content description when focused on each picker wheel
+                            Accessibility.updateContentDescription(fPicker, fLocale);
+                        }
+                    }
+                }
+        );
+    }
+
     public static class SetAccessibilityDelegate implements WheelFunction {
 
         private final Locale locale;

--- a/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
@@ -8,9 +8,7 @@ import android.view.accessibility.AccessibilityManager;
 import android.accessibilityservice.AccessibilityServiceInfo;
 
 import com.henninghall.date_picker.DatePickerPackage;
-import com.henninghall.date_picker.State;
 import com.henninghall.date_picker.Utils;
-import com.henninghall.date_picker.wheels.Wheel;
 import com.henninghall.date_picker.pickers.Picker;
 
 import java.util.Locale;
@@ -83,7 +81,6 @@ public class Accessibility {
      * Get a list of accessibility services currently active
      */
     private static boolean hasAccessibilityFeatureTypeEnabled(int type) {
-
         List<AccessibilityServiceInfo> enabledServices =
                 systemManager.getEnabledAccessibilityServiceList(type);
 
@@ -108,7 +105,6 @@ public class Accessibility {
      */
     private static String pickerValueToDisplayedValue(Picker picker, int value) {
         String[] displayValues = picker.getDisplayedValues();
-
         String displayValue = displayValues[value];
 
         if (displayValue != null) {
@@ -134,14 +130,10 @@ public class Accessibility {
     }
 
     private static String getContentDescriptionLabel(String tagName) {
-        // TODO: create static class property locale used here
-        // Ex add private final static string locale with set
         return Utils.getLocalisedStringFromResources(Accessibility.getLocale(), tagName + "_description");
     }
 
     private static String getSelectedContentDescriptionLabel(String tagName) {
-        // TODO: create static class property locale used here
-        // Ex add private final static string locale with set
         return Utils.getLocalisedStringFromResources(Accessibility.getLocale(), "selected_" + tagName + "_description");
     }
 

--- a/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Accessibility.java
@@ -2,6 +2,7 @@ package com.henninghall.date_picker.ui;
 
 import android.content.Context;
 import android.os.Build;
+import android.os.Bundle;
 import android.view.View;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
@@ -13,6 +14,8 @@ import com.henninghall.date_picker.pickers.Picker;
 
 import java.util.Locale;
 import java.util.List;
+
+import android.view.accessibility.AccessibilityNodeInfo;
 
 public class Accessibility {
     private final static AccessibilityManager systemManager =
@@ -65,6 +68,25 @@ public class Accessibility {
                             // Screen reader reads the content description when focused on each picker wheel
                             Accessibility.updateContentDescription(fPicker);
                         }
+                    }
+
+                    @Override
+                    public boolean performAccessibilityAction(View host, int action, Bundle args) {
+                        int currentValue;
+                        switch (action) {
+                            case AccessibilityNodeInfo.ACTION_SCROLL_FORWARD:
+                                // Increase value when pressing hardware volume up
+                                currentValue = fPicker.getValue();
+                                fPicker.smoothScrollToValue(currentValue - 1);
+                                break;
+                            case AccessibilityNodeInfo.ACTION_SCROLL_BACKWARD:
+                                // Decrease value when pressing hardware volume down
+                                currentValue = fPicker.getValue();
+                                fPicker.smoothScrollToValue(currentValue + 1);
+                                break;
+                        }
+
+                        return super.performAccessibilityAction(host, action, args);
                     }
                 }
         );
@@ -149,5 +171,27 @@ public class Accessibility {
     public static void updateContentDescription(Picker picker){
         String nextContentDescription = getContentDescription(picker);
         picker.getView().setContentDescription(nextContentDescription);
+    }
+
+    /**
+     * Sets the view with associated with given info to behave like a seekBar (slider) when said view receives accessibility focus
+     */
+    public static void setRoleToSlider(AccessibilityNodeInfo info) {
+        // Sets "accessibility role" of the control - affects how the element is read by TalkBack
+        info.setClassName("android.widget.SeekBar");
+
+        // info.addAction(AccessibilityNodeInfo.AccessibilityAction.ACTION_SET_PROGRESS);
+
+        if (Build.VERSION.SDK_INT >= 21) {
+            AccessibilityNodeInfo.AccessibilityAction increaseValue = new AccessibilityNodeInfo.AccessibilityAction(AccessibilityNodeInfo.ACTION_SCROLL_FORWARD, "Increase value");
+            AccessibilityNodeInfo.AccessibilityAction decreaseValue = new AccessibilityNodeInfo.AccessibilityAction(AccessibilityNodeInfo.ACTION_SCROLL_BACKWARD, "Decrease value");
+
+            info.addAction(increaseValue);
+            info.addAction(decreaseValue);
+
+        } else {
+            info.addAction(AccessibilityNodeInfo.ACTION_SCROLL_FORWARD);
+            info.addAction(AccessibilityNodeInfo.ACTION_SCROLL_BACKWARD);
+        }
     }
 }

--- a/android/src/main/java/com/henninghall/date_picker/ui/UIManager.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/UIManager.java
@@ -92,14 +92,13 @@ public class UIManager {
         wheels.applyOnVisible(new HorizontalPadding());
     }
 
-    public void updateContentDescription(Wheel wheel) {
-        // accessibility.update(picker);
-        Accessibility.updateContentDescription(wheel, state);
-    }
+    // public void updateContentDescription(Wheel wheel) {
+    //     Accessibility.updateContentDescription(wheel, state.getLocale());
+    // }
 
-    public void updateAccessibilityValues() {
-        wheels.applyOnAll(new Accessibility.SetAccessibilityDelegate(state.getLocale()));
-    }
+    // public void updateAccessibilityValues() {
+    //     wheels.applyOnAll(new Accessibility.SetAccessibilityDelegate(state.getLocale()));
+    // }
 
     public void updateLastSelectedDate(Calendar date) {
         state.setLastSelectedDate(date);

--- a/android/src/main/java/com/henninghall/date_picker/ui/UIManager.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/UIManager.java
@@ -92,8 +92,9 @@ public class UIManager {
         wheels.applyOnVisible(new HorizontalPadding());
     }
 
-    public void updateContentDescription(Wheel picker) {
-        accessibility.update(picker);
+    public void updateContentDescription(Wheel wheel) {
+        // accessibility.update(picker);
+        Accessibility.updateContentDescription(wheel, state);
     }
 
     public void updateAccessibilityValues() {

--- a/android/src/main/java/com/henninghall/date_picker/ui/UIManager.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/UIManager.java
@@ -21,13 +21,11 @@ public class UIManager {
     private Wheels wheels;
     private FadingOverlay fadingOverlay;
     private WheelScroller wheelScroller = new WheelScroller();
-    private Accessibility accessibility;
 
     public UIManager(State state, View rootView){
         this.state = state;
         this.rootView = rootView;
         wheels = new Wheels(state, rootView);
-        accessibility = new Accessibility(state, wheels);
         addOnChangeListener();
     }
 
@@ -91,14 +89,6 @@ public class UIManager {
     public void updateWheelPadding() {
         wheels.applyOnVisible(new HorizontalPadding());
     }
-
-    // public void updateContentDescription(Wheel wheel) {
-    //     Accessibility.updateContentDescription(wheel, state.getLocale());
-    // }
-
-    // public void updateAccessibilityValues() {
-    //     wheels.applyOnAll(new Accessibility.SetAccessibilityDelegate(state.getLocale()));
-    // }
 
     public void updateLastSelectedDate(Calendar date) {
         state.setLastSelectedDate(date);

--- a/android/src/main/java/com/henninghall/date_picker/ui/WheelChangeListenerImpl.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/WheelChangeListenerImpl.java
@@ -59,7 +59,7 @@ public class WheelChangeListenerImpl implements WheelChangeListener {
             return;
         }
 
-        uiManager.updateContentDescription(picker);
+        // uiManagers.updateContentDescription(picker);
 
         String displayData = uiManager.getDisplayValueString();
 

--- a/android/src/main/java/com/henninghall/date_picker/ui/WheelChangeListenerImpl.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/WheelChangeListenerImpl.java
@@ -59,8 +59,6 @@ public class WheelChangeListenerImpl implements WheelChangeListener {
             return;
         }
 
-        // uiManagers.updateContentDescription(picker);
-
         String displayData = uiManager.getDisplayValueString();
 
         uiManager.updateLastSelectedDate(selectedDate);

--- a/android/src/main/java/com/henninghall/date_picker/ui/Wheels.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Wheels.java
@@ -150,18 +150,6 @@ public class Wheels {
         return getDateString(0);
     }
 
-    /**
-     * REMOVE
-     */
-    String getAccessibleDateTimeString(String timePrefix, String hourTag, String minutesTag) {
-        String date = getDateString();
-        String hour = hourWheel.getValue();
-        String minutes = minutesWheel.getValue();
-        String ampm = ampmWheel.getValue();
-        String time = timePrefix+ " "+ hour + hourTag + minutes + minutesTag + ampm;
-        return date+", "+ time;
-    }
-
     String getDisplayValue() {
         StringBuilder sb = new StringBuilder();
         for (Wheel wheel: getOrderedVisibleWheels()) {

--- a/android/src/main/java/com/henninghall/date_picker/ui/Wheels.java
+++ b/android/src/main/java/com/henninghall/date_picker/ui/Wheels.java
@@ -150,6 +150,9 @@ public class Wheels {
         return getDateString(0);
     }
 
+    /**
+     * REMOVE
+     */
     String getAccessibleDateTimeString(String timePrefix, String hourTag, String minutesTag) {
         String date = getDateString();
         String hour = hourWheel.getValue();

--- a/android/src/main/res/values-fi/strings.xml
+++ b/android/src/main/res/values-fi/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="overlay">Päivämääränvalitsimen päällekkäin</string>
+    <string name="overlay">Päivämääränvalitsin</string>
     <string name="year_description">Valitse Vuosi</string>
     <string name="month_description">Valitse Kuukausi</string>
     <string name="date_description">Valitse Päivämäärä</string>
@@ -8,14 +8,6 @@
     <string name="hour_description">Valitse Tunti</string>
     <string name="minutes_description">Valitse Minuutit</string>
     <string name="ampm_description">Valitse am/pm</string>
-    <string name="selected_year_description">Valittu Vuosi</string>
-    <string name="selected_month_description">Valittu Kuukausi</string>
-    <string name="selected_date_description">Valittu Päivämäärä</string>
-    <string name="selected_day_description">Valittu Päivä</string>
-    <string name="selected_hour_description">Valittu Tunti</string>
-    <string name="selected_minutes_description">Valitut Minuutit</string>
-    <string name="selected_ampm_description">Valittu am/pm</string>
-    <string name="selected_value_description">Arvo on</string>
     <string name="time_tag">Kello on</string>
     <string name="hour_tag">Tunti:</string>
     <string name="minutes_tag">Minuutit</string>

--- a/android/src/main/res/values-he/strings.xml
+++ b/android/src/main/res/values-he/strings.xml
@@ -7,14 +7,6 @@
     <string name="hour_description">בחירת שעה</string>
     <string name="minutes_description">בחירת דקות</string>
     <string name="ampm_description">בחירה ב־AM/PM</string>
-    <string name="selected_year_description">השנה הנבחרת</string>
-    <string name="selected_month_description">החודש הנבחר</string>
-    <string name="selected_date_description">התאריך הנבחר</string>
-    <string name="selected_day_description">היום הנבחר</string>
-    <string name="selected_hour_description">השעה הנבחרת</string>
-    <string name="selected_minutes_description">הדקות שנבחרו</string>
-    <string name="selected_ampm_description">מה נבחר מבחינת AM/PM</string>
-    <string name="selected_value_description">הערך הוא</string>
     <string name="time_tag">השעה היא</string>
     <string name="hour_tag">שעה :</string>
     <string name="minutes_tag">דקות </string>

--- a/android/src/main/res/values-nb/strings.xml
+++ b/android/src/main/res/values-nb/strings.xml
@@ -8,14 +8,6 @@
     <string name="hour_description">Velg time</string>
     <string name="minutes_description">Velg minutter</string>
     <string name="ampm_description">Velg am/pm</string>
-    <string name="selected_year_description">Valgt år</string>
-    <string name="selected_month_description">Valgt måned</string>
-    <string name="selected_date_description">Valgt dato</string>
-    <string name="selected_day_description">Valgt dag</string>
-    <string name="selected_hour_description">Valgt time</string>
-    <string name="selected_minutes_description">Valgte minutter</string>
-    <string name="selected_ampm_description">Valgt am/pm</string>
-    <string name="selected_value_description">Verdien er</string>
     <string name="time_tag">Tiden er</string>
     <string name="hour_tag">Time</string>
     <string name="minutes_tag">Minutter</string>

--- a/android/src/main/res/values-nn/strings.xml
+++ b/android/src/main/res/values-nn/strings.xml
@@ -8,14 +8,6 @@
     <string name="hour_description">Vel time</string>
     <string name="minutes_description">Vel minutt</string>
     <string name="ampm_description">Vel am/pm</string>
-    <string name="selected_year_description">Vald år</string>
-    <string name="selected_month_description">Vald månad</string>
-    <string name="selected_date_description">Vald dato</string>
-    <string name="selected_day_description">Vald dag</string>
-    <string name="selected_hour_description">Vald time</string>
-    <string name="selected_minutes_description">Valde minutt</string>
-    <string name="selected_ampm_description">Vald am/pm</string>
-    <string name="selected_value_description">Verdien er</string>
     <string name="time_tag">Tida er</string>
     <string name="hour_tag">Time</string>
     <string name="minutes_tag">Minutt</string>

--- a/android/src/main/res/values-no/strings.xml
+++ b/android/src/main/res/values-no/strings.xml
@@ -8,14 +8,6 @@
     <string name="hour_description">Velg time</string>
     <string name="minutes_description">Velg minutter</string>
     <string name="ampm_description">Velg am/pm</string>
-    <string name="selected_year_description">Valgt år</string>
-    <string name="selected_month_description">Valgt måned</string>
-    <string name="selected_date_description">Valgt dato</string>
-    <string name="selected_day_description">Valgt dag</string>
-    <string name="selected_hour_description">Valgt time</string>
-    <string name="selected_minutes_description">Valgte minutter</string>
-    <string name="selected_ampm_description">Valgt am/pm</string>
-    <string name="selected_value_description">Verdien er</string>
     <string name="time_tag">Tiden er</string>
     <string name="hour_tag">Time</string>
     <string name="minutes_tag">Minutter</string>

--- a/android/src/main/res/values-sv/strings.xml
+++ b/android/src/main/res/values-sv/strings.xml
@@ -8,14 +8,6 @@
     <string name="hour_description">Välj en timme</string>
     <string name="minutes_description">Välj minuter</string>
     <string name="ampm_description">Välj am/pm</string>
-    <string name="selected_year_description">Valt år</string>
-    <string name="selected_month_description">Valt månad</string>
-    <string name="selected_date_description">Valt datum</string>
-    <string name="selected_day_description">Vald dag</string>
-    <string name="selected_hour_description">Vald timme</string>
-    <string name="selected_minutes_description">Valda minuter</string>
-    <string name="selected_ampm_description">Vald am/pm</string>
-    <string name="selected_value_description">Värdet är</string>
     <string name="time_tag">Tiden är</string>
     <string name="hour_tag">Timme:</string>
     <string name="minutes_tag">Minuter</string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -7,14 +7,6 @@
     <string name="hour_description">Select Hour</string>
     <string name="minutes_description">Select Minutes</string>
     <string name="ampm_description">Select AM/PM</string>
-    <string name="selected_year_description">Selected Year</string>
-    <string name="selected_month_description">Selected Month</string>
-    <string name="selected_date_description">Selected Date</string>
-    <string name="selected_day_description">Selected Day</string>
-    <string name="selected_hour_description">Selected Hour</string>
-    <string name="selected_minutes_description">Selected Minutes</string>
-    <string name="selected_ampm_description">Selected AM/PM</string>
-    <string name="selected_value_description">Value is</string>
     <string name="time_tag">Time is</string>
     <string name="hour_tag">Hour :</string>
     <string name="minutes_tag">Minutes </string>


### PR DESCRIPTION
- Improve `IosClone` spoken feedback when wheel: 
   - receives accessibility focus
      - "12th of May, set date, slider, use volume keys to adjust"
      - You can then use volume keys or 2-finger scroll to adjust value 
  - when value changes
     - Notify TalkBack about changes through accessibility events instead of explicitly announcing
  - When used with physical keyboard, functions like OS sliders (android.widget.seekBar). For example brightness slider in notification shade. 
- Use accessibility initialisation listener to set contentDescription and other traits
- Moved accessibility logic only affecting IosClone from wheels to IosClone
- Refactor Accessibility class to be more tools, less use-case specific methods

Video has sound

https://user-images.githubusercontent.com/3703618/133783230-2eaa248d-61d6-46f1-993d-79052d4681ec.mp4


