### PR TITLE
fix: fixed is clone overlay focusable by talkback

### DIFF
--- a/android/src/main/res/layout/ios_clone.xml
+++ b/android/src/main/res/layout/ios_clone.xml
@@ -168,6 +168,7 @@
             android:layout_height="0dp"
             android:rotation="180"
             android:layout_weight=".15"
+            android:importantForAccessibility="no"
             />
 
         <View
@@ -182,6 +183,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight=".15"
+            android:importantForAccessibility="no"
         />
     </LinearLayout>
 


### PR DESCRIPTION
The PR to resolve https://github.com/henninghall/react-native-date-picker/issues/372#issuecomment-979941197