### PR TITLE
fix: show picker modal from within another modal

### DIFF
--- a/ios/RNDatePicker/RNDatePickerManager.m
+++ b/ios/RNDatePicker/RNDatePickerManager.m
@@ -139,7 +139,13 @@ RCT_EXPORT_METHOD(openPicker:(NSDictionary *) props
             [popPresenter setPermittedArrowDirections: (UIPopoverArrowDirection) 0];
         }
         
-        [rootViewController presentViewController:alertController animated:YES completion:nil];
+        // Finding the top view controller which is neccessary to be able to show the picker from within modal
+        UIViewController *topViewController = rootViewController;
+        while (topViewController.presentedViewController){
+            topViewController = topViewController.presentedViewController;
+        }
+        
+        [topViewController presentViewController:alertController animated:YES completion:nil];
     });
 
 }


### PR DESCRIPTION
Fixes https://github.com/henninghall/react-native-date-picker/issues/398