### PR TITLE
Prevent the opening of multiple modals on rerender

### DIFF
--- a/src/DatePickerAndroid.js
+++ b/src/DatePickerAndroid.js
@@ -16,16 +16,18 @@ const timeModeWidth = 240
 const defaultWidth = 310
 
 class DatePickerAndroid extends React.PureComponent {
+  _isAlreadyOpen = false;
   render() {
     const props = this.getProps()
     if (props.modal) {
-      if (props.open) {
+      if (props.open && !this._isAlreadyOpen) {
+        this._isAlreadyOpen = true;
         NativeModules.RNDatePicker.openPicker(
           props,
           this._onConfirm,
-          this.props.onCancel
+          this._onCancel
         )
-      }
+      } 
       return null
     }
 
@@ -77,7 +79,13 @@ class DatePickerAndroid extends React.PureComponent {
     return addMinutes(date, this.props.timeZoneOffsetInMinutes).toISOString()
   }
 
+  _onCancel = () => {
+    this._isAlreadyOpen = false
+    this.props.onCancel()
+  }
+
   _onConfirm = (isoDate) => {
+    this._isAlreadyOpen = false
     this.props.onConfirm(this._fromIsoWithTimeZoneOffset(isoDate))
   }
 }

--- a/src/DatePickerIOS.js
+++ b/src/DatePickerIOS.js
@@ -10,7 +10,8 @@ const RCTDatePickerIOS = requireNativeComponent('RNDatePicker')
 
 export default class DatePickerIOS extends React.Component {
   _picker = null
-
+  _isAlreadyOpen = false;
+  
   componentDidUpdate() {
     if (this.props.date) {
       const propsTimeStamp = this.props.date.getTime()
@@ -40,18 +41,25 @@ export default class DatePickerIOS extends React.Component {
   }
 
   _onConfirm = ({ timestamp }) => {
+    this._isAlreadyOpen = false
     this.props.onConfirm(new Date(timestamp))
+  }
+
+  _onCancel = () => {
+    this._isAlreadyOpen = false
+    this.props.onCancel()
   }
 
   render() {
     const props = this._toIosProps(this.props)
 
     if (props.modal) {
-      if (props.open) {
+      if (props.open && !this._isAlreadyOpen) {
+        this._isAlreadyOpen = true;
         NativeModules.RNDatePickerManager.openPicker(
           props,
           this._onConfirm,
-          props.onCancel
+          this._onCancel,
         )
       }
       return null


### PR DESCRIPTION
If the Date Picker is "open" and the screen is rerendered, additional date pickers may be opened. This bug fix keeps track of if the picker is already open and if so does not re-open an additional one.