### PR TITLE
fix: duplicate 12's renderd in android native variant

### DIFF
--- a/android/src/main/java/com/henninghall/date_picker/HourDisplayBugWorkaround.java
+++ b/android/src/main/java/com/henninghall/date_picker/HourDisplayBugWorkaround.java
@@ -1,0 +1,38 @@
+package com.henninghall.date_picker;
+
+import com.henninghall.date_picker.models.Variant;
+
+/**
+ * This workaround prevents a bug existing in the NativeAndroid variant.
+ * The bug displays duplicated "12" hours string when the current time is set to "1".
+ * Haven't found the root cause of this bug but since this bug only occurs in the NativeAndroid
+ * variant there are reasons to believe there is a internal bug in Android's NumberPicker for this
+ * use case.
+ *
+ * More info about the bug:
+ * https://github.com/henninghall/react-native-date-picker/issues/382
+ */
+public class HourDisplayBugWorkaround {
+
+    private final State state;
+
+    public HourDisplayBugWorkaround(State state) {
+        this.state = state;
+    }
+
+    private boolean shouldApply(String displayValue) {
+        if(state.getVariant() != Variant.nativeAndroid) return false;
+        if(displayValue.length() != 1) return false;
+        return true;
+    }
+
+    private String adjust(String displayValue) {
+        return " " + displayValue + " ";
+    }
+
+    public String adjustValueIfNecessary(String displayValue) {
+        if(!shouldApply(displayValue)) return displayValue;
+        return adjust(displayValue);
+    }
+
+}

--- a/android/src/main/java/com/henninghall/date_picker/wheels/HourWheel.java
+++ b/android/src/main/java/com/henninghall/date_picker/wheels/HourWheel.java
@@ -2,9 +2,9 @@ package com.henninghall.date_picker.wheels;
 
 import android.graphics.Paint;
 
+import com.henninghall.date_picker.HourDisplayBugWorkaround;
 import com.henninghall.date_picker.pickers.Picker;
 import com.henninghall.date_picker.State;
-import com.henninghall.date_picker.Utils;
 import com.henninghall.date_picker.models.Mode;
 
 import java.util.ArrayList;
@@ -12,8 +12,11 @@ import java.util.Calendar;
 
 public class HourWheel extends Wheel {
 
+    private final HourDisplayBugWorkaround hourDisplayAdjustment;
+
     public HourWheel(Picker picker, State id) {
         super(picker, id);
+        this.hourDisplayAdjustment = new HourDisplayBugWorkaround(state);
     }
 
     @Override
@@ -31,6 +34,11 @@ public class HourWheel extends Wheel {
             cal.add(Calendar.HOUR_OF_DAY, 1);
         }
         return values;
+    }
+
+    @Override
+    public String toDisplayValue(String value) {
+        return hourDisplayAdjustment.adjustValueIfNecessary(value);
     }
 
     @Override


### PR DESCRIPTION
Workaround for https://github.com/henninghall/react-native-date-picker/issues/382