### PR TITLE
Feat: add neutral button support

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,11 @@ export default () => {
 | `open`                    | Modal only: Boolean indicating if modal should be open.                                                                                                                                                                                                                                                               |
 | `onConfirm`               | Modal only: Date callback when user presses confirm button                                                                                                                                                                                                                                                            |
 | `onCancel`                | Modal only: Callback for when user presses cancel button or closing the modal by pressing outside it.                                                                                                                                                                                                                 |
+| `onNeutral`               | Modal only: Callback for when user presses the optional neutral button. Only invoked if `neutralText` prop is provided.
 | `title`                   | Modal only: Title text. Can be set to null to remove text.                                                                                                                                                                                                                                                            |
 | `confirmText`             | Modal only: Confirm button text.                                                                                                                                                                                                                                                                                      |
 | `cancelText`              | Modal only: Cancel button text.                                                                                                                                                                                                                                                                                       |
+| `neutralText`             | Modal only: Optional neutral button text. If not set, the button will not be displayed.
 
 ## Linking
 

--- a/android/src/main/java/com/henninghall/date_picker/DatePickerModule.java
+++ b/android/src/main/java/com/henninghall/date_picker/DatePickerModule.java
@@ -7,6 +7,8 @@ import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 
+import com.henninghall.date_picker.Emitter;
+
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -14,8 +16,12 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.Arguments;
 
 import net.time4j.android.ApplicationStarter;
+
+import java.util.Objects;
 
 public class DatePickerModule extends ReactContextBaseJavaModule {
 
@@ -35,14 +41,14 @@ public class DatePickerModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void openPicker(ReadableMap props, Callback onConfirm, Callback onCancel, Callback onNeutral){
+    public void openPicker(ReadableMap props, Callback onConfirm, Callback onCancel){
         PickerView picker = createPicker(props);
-        AlertDialog dialog = createDialog(props, picker, onConfirm, onCancel, onNeutral);
+        AlertDialog dialog = createDialog(props, picker, onConfirm, onCancel);
         dialog.show();
     }
 
     private AlertDialog createDialog(
-            ReadableMap props, final PickerView picker, final Callback onConfirm, final Callback onCancel, final Callback onNeutral) {
+            ReadableMap props, final PickerView picker, final Callback onConfirm, final Callback onCancel) {
         String title = props.getString("title");
         String confirmText = props.getString("confirmText");
         String neutralText = props.getString("neutralText");
@@ -72,10 +78,13 @@ public class DatePickerModule extends ReactContextBaseJavaModule {
                     }
                 });
 
-        if(neutralText != null && onNeutral != null) {
+        if(neutralText != null) {
             dialogBuilder.setNeutralButton(neutralText, new DialogInterface.OnClickListener() {
                 public void onClick(DialogInterface dialog, int id) {
-                    onNeutral.invoke();
+                    WritableMap params = Arguments.createMap();
+                    params.putString("eventProperty", "neutralButton");
+
+                    Emitter.sendEvent("nativeButtonPress", params);
                     dialog.dismiss();
                 }
             });

--- a/android/src/main/java/com/henninghall/date_picker/DatePickerModule.java
+++ b/android/src/main/java/com/henninghall/date_picker/DatePickerModule.java
@@ -35,20 +35,21 @@ public class DatePickerModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void openPicker(ReadableMap props, Callback onConfirm, Callback onCancel){
+    public void openPicker(ReadableMap props, Callback onConfirm, Callback onCancel, Callback onNeutral){
         PickerView picker = createPicker(props);
-        AlertDialog dialog = createDialog(props, picker, onConfirm, onCancel);
+        AlertDialog dialog = createDialog(props, picker, onConfirm, onCancel, onNeutral);
         dialog.show();
     }
 
     private AlertDialog createDialog(
-            ReadableMap props, final PickerView picker, final Callback onConfirm, final Callback onCancel) {
+            ReadableMap props, final PickerView picker, final Callback onConfirm, final Callback onCancel, final Callback onNeutral) {
         String title = props.getString("title");
         String confirmText = props.getString("confirmText");
+        String neutralText = props.getString("neutralText");
         final String cancelText = props.getString("cancelText");
         final View pickerWithMargin = withTopMargin(picker);
 
-        return new AlertDialog.Builder(DatePickerPackage.context.getCurrentActivity())
+        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(DatePickerPackage.context.getCurrentActivity())
                 .setTitle(title)
                 .setCancelable(true)
                 .setView(pickerWithMargin)
@@ -69,8 +70,18 @@ public class DatePickerModule extends ReactContextBaseJavaModule {
                     public void onCancel(DialogInterface dialogInterface) {
                         onCancel.invoke();
                     }
-                })
-                .create();
+                });
+
+        if(neutralText != null && onNeutral != null) {
+            dialogBuilder.setNeutralButton(neutralText, new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int id) {
+                    onNeutral.invoke();
+                    dialog.dismiss();
+                }
+            });
+        }
+
+        return dialogBuilder.create();
     }
 
     private PickerView createPicker(ReadableMap props){

--- a/android/src/main/java/com/henninghall/date_picker/Emitter.java
+++ b/android/src/main/java/com/henninghall/date_picker/Emitter.java
@@ -2,6 +2,8 @@ package com.henninghall.date_picker;
 
 import android.view.View;
 
+import androidx.annotation.Nullable;
+
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
@@ -25,6 +27,10 @@ public class Emitter {
         event.putString("date", dateString);
         event.putString("dateString", displayValueString);
         eventEmitter().receiveEvent(view.getId(), "dateChange", event);
+    }
+
+    public static void sendEvent(String eventName, @Nullable WritableMap params) {
+        eventEmitter().emit(eventName, params);
     }
 
 }

--- a/android/src/main/java/com/henninghall/date_picker/Emitter.java
+++ b/android/src/main/java/com/henninghall/date_picker/Emitter.java
@@ -30,7 +30,7 @@ public class Emitter {
     }
 
     public static void sendEvent(String eventName, @Nullable WritableMap params) {
-        eventEmitter().emit(eventName, params);
+        deviceEventEmitter().emit(eventName, params);
     }
 
 }

--- a/examples/detox/e2e/tests/modal.spec.js
+++ b/examples/detox/e2e/tests/modal.spec.js
@@ -17,4 +17,14 @@ describe('Modal', () => {
     await element(by.text('CONFIRM')).tap()
     await expect(element(by.id('day'))).not.toBeVisible()
   })
+
+  it('can open modal and press neutral button', async () => {
+    await element(by.id('openModal')).tap()
+    await expect(element(by.text('Neutral'))).toBeVisible()
+    await element(by.text('Neutral')).tap()
+
+    await element(by.text('Neutral button pressed!')).toBeVisible()
+    await element(by.text('OK')).tap()
+    await expect(element(by.id('day'))).not.toBeVisible()
+  })
 })

--- a/examples/detox/src/examples/Modal.js
+++ b/examples/detox/src/examples/Modal.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button, View, Text } from 'react-native'
+import { Button, View, Text, Alert } from 'react-native'
 import DatePicker from 'react-native-date-picker'
 
 export default class ModalExample extends React.Component {
@@ -18,6 +18,8 @@ export default class ModalExample extends React.Component {
         date={this.state.date}
         onConfirm={(date) => this.setState({ date, open: false })}
         onCancel={() => this.setState({ open: false })}
+        onNeutral={() => Alert.alert("Neutral button pressed!")}
+        neutralText="Neutral"
         androidVariant="nativeAndroid"
       />
       <Text style={{ marginTop: 20, fontSize: 26 }}>

--- a/index.d.ts
+++ b/index.d.ts
@@ -92,11 +92,17 @@ export interface DatePickerProps extends ViewProps {
   /** Modal callback invoked when user presses the cancel button or closes the modal by a press outside  */
   onCancel?: () => void
 
+  /** Modal callback invoked when user presses the optional neutral button */
+  onNeutral?: () => void
+
   /** Modal confirm button text */
   confirmText?: string
 
   /** Modal cancel button text */
   cancelText?: string
+
+  /** Text of an optional neutral modal button */
+  neutralText?: string
 
   /** Modal title. Set to null to remove */
   title?: string | null

--- a/ios/RNDatePicker/DatePickerEventEmitterModule.h
+++ b/ios/RNDatePicker/DatePickerEventEmitterModule.h
@@ -1,0 +1,6 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+@interface DatePickerEventEmitterModule : RCTEventEmitter <RCTBridgeModule>
+
+@end

--- a/ios/RNDatePicker/DatePickerEventEmitterModule.m
+++ b/ios/RNDatePicker/DatePickerEventEmitterModule.m
@@ -1,0 +1,27 @@
+#import "DatePickerEventEmitterModule.h"
+
+@implementation DatePickerEventEmitterModule
+
+RCT_EXPORT_MODULE();
+
+- (NSArray<NSString*> *)supportedEvents {
+  return @[@"neutralButtonPress"];
+}
+
+// Allocate as a singleton to avoid the bridge not being initialized exception
+// See https://github.com/facebook/react-native/issues/15421
++ (id)allocWithZone:(NSZone *)zone {
+    static DatePickerEventEmitterModule *sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [super allocWithZone:zone];
+    });
+    return sharedInstance;
+}
+
+- (void)sendNeutralButtonPressEvent
+{
+    [self sendEventWithName:@"neutralButtonPress" body:@""];
+}
+
+@end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-date-picker",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "A datetime picker for React Native. In-modal or inlined. Supports Android and iOS.",
   "main": "src/index.js",
   "scripts": {

--- a/src/DatePickerAndroid.js
+++ b/src/DatePickerAndroid.js
@@ -5,11 +5,9 @@ function addMinutes(date, minutesToAdd) {
   return new Date(date.valueOf() + minutesToAdd * 60 * 1000)
 }
 
-const NativeDatePicker = requireNativeComponent(
-  `DatePickerManager`,
-  DatePickerAndroid,
-  { nativeOnly: { onChange: true } }
-)
+const NativeDatePicker = requireNativeComponent(`DatePickerManager`, DatePickerAndroid, {
+  nativeOnly: { onChange: true },
+})
 
 const height = 180
 const timeModeWidth = 240
@@ -23,7 +21,8 @@ class DatePickerAndroid extends React.PureComponent {
         NativeModules.RNDatePicker.openPicker(
           props,
           this._onConfirm,
-          this.props.onCancel
+          this.props.onCancel,
+          this.props.onNeutral
         )
       }
       return null
@@ -55,12 +54,10 @@ class DatePickerAndroid extends React.PureComponent {
   }
 
   _maximumDate = () =>
-    this.props.maximumDate &&
-    this._toIsoWithTimeZoneOffset(this.props.maximumDate)
+    this.props.maximumDate && this._toIsoWithTimeZoneOffset(this.props.maximumDate)
 
   _minimumDate = () =>
-    this.props.minimumDate &&
-    this._toIsoWithTimeZoneOffset(this.props.minimumDate)
+    this.props.minimumDate && this._toIsoWithTimeZoneOffset(this.props.minimumDate)
 
   _date = () => this._toIsoWithTimeZoneOffset(this.props.date)
 
@@ -71,8 +68,7 @@ class DatePickerAndroid extends React.PureComponent {
   }
 
   _toIsoWithTimeZoneOffset = (date) => {
-    if (this.props.timeZoneOffsetInMinutes === undefined)
-      return date.toISOString()
+    if (this.props.timeZoneOffsetInMinutes === undefined) return date.toISOString()
 
     return addMinutes(date, this.props.timeZoneOffsetInMinutes).toISOString()
   }

--- a/src/DatePickerAndroid.js
+++ b/src/DatePickerAndroid.js
@@ -21,7 +21,7 @@ class DatePickerAndroid extends React.PureComponent {
 
     this.eventListener = eventEmitter.addListener('nativeButtonPress', (event) => {
       if(event.eventProperty === 'neutralButton') {
-        this.props.onNeutral()
+        this.props.onNeutral && this.props.onNeutral()
       }
     })
   }

--- a/src/DatePickerIOS.js
+++ b/src/DatePickerIOS.js
@@ -1,10 +1,23 @@
 import React, { useEffect } from 'react'
-import { StyleSheet, View, requireNativeComponent, NativeModules } from 'react-native'
+import {
+  StyleSheet,
+  View,
+  requireNativeComponent,
+  NativeModules, NativeEventEmitter,
+} from 'react-native'
 
 const RCTDatePickerIOS = requireNativeComponent('RNDatePicker')
 
 export default class DatePickerIOS extends React.Component {
   _picker = null
+
+  componentDidMount() {
+    const eventEmitter = new NativeEventEmitter(NativeModules.DatePickerEventEmitterModule)
+
+    this.eventListener = eventEmitter.addListener('neutralButtonPress', (event) => {
+      this.props.onNeutral()
+    })
+  }
 
   componentDidUpdate() {
     if (this.props.date) {
@@ -17,9 +30,14 @@ export default class DatePickerIOS extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    this.eventListener.remove()
+  }
+
   _onChange = (event) => {
     const nativeTimeStamp = event.nativeEvent.timestamp
-    this.props.onDateChange && this.props.onDateChange(new Date(nativeTimeStamp))
+    this.props.onDateChange &&
+    this.props.onDateChange(new Date(nativeTimeStamp))
   }
 
   _toIosProps = (props) => {
@@ -43,26 +61,25 @@ export default class DatePickerIOS extends React.Component {
     if (props.modal) {
       if (props.open) {
         NativeModules.RNDatePickerManager.openPicker(
-          props,
-          this._onConfirm,
-          props.onCancel,
-          props.onNeutral
+            props,
+            this._onConfirm,
+            props.onCancel
         )
       }
       return null
     }
 
     return (
-      <RCTDatePickerIOS
-        key={props.textColor} // preventing "Today" string keep old text color when text color changes
-        ref={(picker) => {
-          this._picker = picker
-        }}
-        onChange={this._onChange}
-        onStartShouldSetResponder={() => true}
-        onResponderTerminationRequest={() => false}
-        {...props}
-      />
+        <RCTDatePickerIOS
+            key={props.textColor} // preventing "Today" string keep old text color when text color changes
+            ref={(picker) => {
+              this._picker = picker
+            }}
+            onChange={this._onChange}
+            onStartShouldSetResponder={() => true}
+            onResponderTerminationRequest={() => false}
+            {...props}
+        />
     )
   }
 }

--- a/src/DatePickerIOS.js
+++ b/src/DatePickerIOS.js
@@ -1,10 +1,5 @@
 import React, { useEffect } from 'react'
-import {
-  StyleSheet,
-  View,
-  requireNativeComponent,
-  NativeModules,
-} from 'react-native'
+import { StyleSheet, View, requireNativeComponent, NativeModules } from 'react-native'
 
 const RCTDatePickerIOS = requireNativeComponent('RNDatePicker')
 
@@ -24,8 +19,7 @@ export default class DatePickerIOS extends React.Component {
 
   _onChange = (event) => {
     const nativeTimeStamp = event.nativeEvent.timestamp
-    this.props.onDateChange &&
-      this.props.onDateChange(new Date(nativeTimeStamp))
+    this.props.onDateChange && this.props.onDateChange(new Date(nativeTimeStamp))
   }
 
   _toIosProps = (props) => {
@@ -51,7 +45,8 @@ export default class DatePickerIOS extends React.Component {
         NativeModules.RNDatePickerManager.openPicker(
           props,
           this._onConfirm,
-          props.onCancel
+          props.onCancel,
+          props.onNeutral
         )
       }
       return null

--- a/src/DatePickerIOS.js
+++ b/src/DatePickerIOS.js
@@ -15,7 +15,7 @@ export default class DatePickerIOS extends React.Component {
     const eventEmitter = new NativeEventEmitter(NativeModules.DatePickerEventEmitterModule)
 
     this.eventListener = eventEmitter.addListener('neutralButtonPress', (event) => {
-      this.props.onNeutral()
+      this.props.onNeutral && this.props.onNeutral()
     })
   }
 

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -13,8 +13,10 @@ const modalPropTypes = {
   open: PropTypes.bool,
   onConfirm: PropTypes.func,
   onCancel: PropTypes.func,
+  onNeutral: PropTypes.func,
   confirmText: PropTypes.string,
   cancelText: PropTypes.string,
+  neutralText: PropTypes.string,
   title: PropTypes.string,
 }
 


### PR DESCRIPTION
In some use cases, it's convenient to have a 3rd, neutral, button present in the `Modal` for actions such as clearing the date.
This PR aims to implement this support.
- The button is present only when `neutralText` prop is passed
- The bridging of button's click events is done using `EventEmitter` and its respective listeners
Thank you for working on this library! Please see the attached usage videos and feel free to change this around.

![neutral-button-android](https://user-images.githubusercontent.com/23032136/159730369-c5212c63-b342-4b4f-9f2f-97f5f8c1bbec.gif)

https://user-images.githubusercontent.com/23032136/159732108-a62f93c7-25b6-48be-a2de-f76aaabdc6be.mp4

