### PR TITLE
Use ViewPropTypes from deprecated-react-native-prop-types to be compa…

### DIFF
--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -1,4 +1,5 @@
-import { Platform, ViewPropTypes } from 'react-native'
+import { Platform } from 'react-native'
+import { ViewPropTypes } from 'deprecated-react-native-prop-types'
 import PropTypes from 'prop-types'
 
 const androidPropTypes = {


### PR DESCRIPTION
Use ViewPropTypes from deprecated-react-native-prop-types to be compatible with react-native 0.68

Not sure if 'deprecated-react-native-prop-types' should be added into dependencies in package.json
Even 'react-native' is not in deps, however works somehow...