### PR TITLE
add import to fix builds failing on iOS

### DIFF
--- a/ios/RNDatePicker/DatePicker.m
+++ b/ios/RNDatePicker/DatePicker.m
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
+#import "RCTComponent.h"
 #import "DatePicker.h"
 
 #import "RCTUtils.h"


### PR DESCRIPTION
fixes https://github.com/henninghall/react-native-date-picker/issues/506 and https://github.com/henninghall/react-native-date-picker/issues/474