### PR TITLE
Support dark theme by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Platform } from 'react-native'
+import { Platform, Appearance } from 'react-native'
 import DatePickerIOS from './DatePickerIOS'
 import DatePickerAndroid from './DatePickerAndroid'
 import propTypes from './propTypes'
@@ -19,7 +19,8 @@ const DatePickerWrapper = (props) => {
     <DatePicker
       ref={props.innerRef}
       {...props}
-      textColor={colorToHex(props.textColor)}
+      textColor={colorToHex(getTextColor(props))}
+      theme={getTheme(props)}
       fadeToColor={colorToHex(props.fadeToColor)}
       title={getTitle(props)}
       confirmText={props.confirmText ? props.confirmText : 'Confirm'}
@@ -29,6 +30,19 @@ const DatePickerWrapper = (props) => {
       mode={props.mode ? props.mode : 'datetime'}
     />
   )
+}
+
+const getTheme = (props) => {
+  if (props.theme) return props.theme
+  if (!Appearance) return 'auto'
+  return Appearance.getColorScheme()
+}
+
+const getTextColor = (props) => {
+  if (props.textColor) return props.textColor
+  const darkTheme = getTheme(props) === 'dark'
+  if (darkTheme) return 'white'
+  return undefined
 }
 
 const getAndroidVariant = (props) => {


### PR DESCRIPTION
Fixes https://github.com/henninghall/react-native-date-picker/issues/527, https://github.com/henninghall/react-native-date-picker/issues/483

<img width="313" alt="Screenshot 2022-07-17 at 21 48 19" src="https://user-images.githubusercontent.com/1652607/179423062-db85c5e8-9457-496e-9a1f-d1485e6ed7e1.png"><img width="249" alt="Screenshot 2022-07-17 at 21 47 57" src="https://user-images.githubusercontent.com/1652607/179423066-b5530ad9-48c4-4557-82b6-77304af5246f.png">
