### PR TITLE
remove buildToolsVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,6 @@ def safeExtGet(prop, fallback) {
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 29)
-    buildToolsVersion safeExtGet('buildToolsVersion', "25.0.3")
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 18)


### PR DESCRIPTION
buildToolsVersion is no longer required since Android Gradle Plugin 3.1 https://developer.android.com/studio/releases/gradle-plugin#3-1-0