### PR TITLE
fix: modal theming on android

### DIFF
--- a/android/src/main/java/com/henninghall/date_picker/DatePickerModule.java
+++ b/android/src/main/java/com/henninghall/date_picker/DatePickerModule.java
@@ -48,7 +48,7 @@ public class DatePickerModule extends ReactContextBaseJavaModule {
         final String cancelText = props.getString("cancelText");
         final View pickerWithMargin = withTopMargin(picker);
 
-        return new AlertDialog.Builder(DatePickerPackage.context.getCurrentActivity())
+        return new AlertDialog.Builder(DatePickerPackage.context.getCurrentActivity(), getTheme(props))
                 .setTitle(title)
                 .setCancelable(true)
                 .setView(pickerWithMargin)
@@ -71,6 +71,17 @@ public class DatePickerModule extends ReactContextBaseJavaModule {
                     }
                 })
                 .create();
+    }
+
+    private int getTheme(ReadableMap props) {
+        int defaultTheme = 0;
+        String theme = props.getString("theme");
+        if(theme == null) return defaultTheme;
+        switch (theme){
+            case "light": return AlertDialog.THEME_DEVICE_DEFAULT_LIGHT;
+            case "dark": return AlertDialog.THEME_DEVICE_DEFAULT_DARK;
+            default: return defaultTheme;
+        }
     }
 
     private PickerView createPicker(ReadableMap props){


### PR DESCRIPTION
Previously the `theme` prop wasn't taken into consideration when displaying the modal causing the modal to always listen to the system theme, even if the theme was overwritten by the `theme` prop.