### PR TITLE
fix: incorrect initial date when date in past

### DIFF
--- a/.maestro/display-text.yml
+++ b/.maestro/display-text.yml
@@ -1,8 +1,35 @@
 appId: com.rn069
 ---
+- runFlow:
+    file: utils/set-timezone.yml
+    env:
+      REGION: Sweden
+      GMT: GMT+01:00
+      STATE: ''
+
+# test: can have initial date in past
 - runFlow: utils/launch.yml
-- tapOn: androidVariant
-- tapOn: nativeAndroid
+- runFlow:
+    file: utils/change-prop.yml
+    env:
+      PROP: maximumDate
+      VALUE: undefined
+- runFlow:
+    file: utils/change-prop.yml
+    env:
+      PROP: minimumDate
+      VALUE: undefined
+- runFlow:
+    file: utils/change-prop.yml
+    env:
+      PROP: date
+      VALUE: '1999-01-01'
+- runFlow: utils/swipe-wheel-1.yml
+- assertVisible: '1999-01-02 01:00:00'
+
+- runFlow: utils/reset.yml
+
+# test: display text
 - runFlow:
     file: utils/change-prop.yml
     env:

--- a/.maestro/utils/swipe-wheel-1.yml
+++ b/.maestro/utils/swipe-wheel-1.yml
@@ -2,4 +2,4 @@ appId: com.rn069
 ---
 - swipe:
     start: 25%, 40%
-    end: 25%, 30%
+    end: 25%, 35%

--- a/android/src/main/java/com/henninghall/date_picker/props/Prop.java
+++ b/android/src/main/java/com/henninghall/date_picker/props/Prop.java
@@ -17,10 +17,6 @@ public abstract class Prop<T> {
         this.value = toValue(value);
     }
 
-    public void setValue(T value){
-        this.value = value;
-    }
-
     public T getValue(){
         return value;
     }

--- a/android/src/main/java/com/henninghall/date_picker/wheels/DayWheel.java
+++ b/android/src/main/java/com/henninghall/date_picker/wheels/DayWheel.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 public class DayWheel extends Wheel {
 
     private String todayValue;
-    private static int defaultNumberOfDays = Calendar.getInstance().getActualMaximum(Calendar.DAY_OF_YEAR);
+    private static int defaultNumberOfDays = 150;
     private HashMap<String, String> displayValues;
 
     public DayWheel(Picker picker, State state) {
@@ -54,7 +54,7 @@ public class DayWheel extends Wheel {
             cal = (Calendar) max.clone();
             cal.add(Calendar.DATE, -cal.getActualMaximum(Calendar.DAY_OF_YEAR) / 2);
         } else {
-            cal = (Calendar) getInitialDate().clone();
+            cal = getInitialDate();
             cal.add(Calendar.DATE, -defaultNumberOfDays / 2);
         }
         return cal;
@@ -70,18 +70,10 @@ public class DayWheel extends Wheel {
             cal = (Calendar) min.clone();
             cal.add(Calendar.DATE, cal.getActualMaximum(Calendar.DAY_OF_YEAR) / 2);
         } else {
-            cal = (Calendar) getInitialDate().clone();
-            cal.setTime(new Date());
+            cal = getInitialDate();
             cal.add(Calendar.DATE, defaultNumberOfDays / 2);
         }
         return cal;
-    }
-
-    private void resetToMidnight(Calendar cal){
-        cal.set(Calendar.HOUR_OF_DAY, 0);
-        cal.set(Calendar.MINUTE, 0);
-        cal.set(Calendar.SECOND, 0);
-        cal.set(Calendar.MILLISECOND, 0);
     }
 
     private String getValue(Calendar cal){
@@ -141,7 +133,7 @@ public class DayWheel extends Wheel {
 
     // Rounding cal to closest minute interval
     private Calendar getInitialDate() {
-        Calendar cal = Calendar.getInstance();
+        Calendar cal = state.getDate();
         int minuteInterval = state.getMinuteInterval();
         if(minuteInterval <= 1) return cal;
         SimpleDateFormat minuteFormat = new SimpleDateFormat("mm", state.getLocale());


### PR DESCRIPTION
Wrong date was initially selected on android if date was in past and no max or min date was set. 

Fixes https://github.com/henninghall/react-native-date-picker/issues/633