### PR TITLE
fix: prevent crash/empty wheels at unknown locale

### DIFF
--- a/.maestro/display-text.yml
+++ b/.maestro/display-text.yml
@@ -56,3 +56,13 @@ appId: com.rn069
 - assertVisible:
     id: dateStringOutput
     text: 'CN 2 thg 11200 SA '
+
+# Should be possible to use picker with invalid locale
+- runFlow: utils/launch.yml
+- runFlow:
+    file: utils/change-prop.yml
+    env:
+      PROP: locale
+      VALUE: xx
+- runFlow: utils/swipe-wheel-1.yml
+- assertVisible: '2000-01-02 00:00:00'

--- a/android/src/main/java/com/henninghall/date_picker/Formats.java
+++ b/android/src/main/java/com/henninghall/date_picker/Formats.java
@@ -84,6 +84,7 @@ public class Formats {
         put("kn", mapOf("EEE, d MMM", "d", "y"));
         put("ko", mapOf("MMM d일 EEE", "d일", "y년"));
         put("ky", mapOf("d-MMM, EEE", "d", "y"));
+        put("lb", mapOf("EEE d MMM", "d", "y"));
         put("ln", mapOf("EEE d MMM", "d", "y"));
         put("lo", mapOf("EEE d MMM", "d", "y"));
         put("lt", mapOf("MM-dd, EEE", "dd", "y"));

--- a/android/src/main/java/com/henninghall/date_picker/LocaleUtils.java
+++ b/android/src/main/java/com/henninghall/date_picker/LocaleUtils.java
@@ -30,7 +30,7 @@ public class LocaleUtils {
             try {
                 String firstPartOfLanguageTag = languageTag.substring(0, languageTag.indexOf("_"));
                 return Formats.get(firstPartOfLanguageTag, format);
-            } catch (Formats.FormatNotFoundException ex) {
+            } catch (Formats.FormatNotFoundException | IndexOutOfBoundsException ex) {
                 return Formats.defaultFormat.get(format);
             }
         }


### PR DESCRIPTION
- prevent empty wheels when an unknown locale passed
- support Luxembourgish (lb) locale

Fixes https://github.com/henninghall/react-native-date-picker/issues/623