### PR TITLE
Adjust Android build.gradle to to run project with Gradle 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,8 @@ android {
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
     }
 
+    buildFeatures.buildConfig true
+
     sourceSets {
         main {
             if (isNewArchitectureEnabled()) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,8 +23,14 @@ android {
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
     }
 
-    buildFeatures.buildConfig true
-    namespace 'com.henninghall.date_picker'
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+        namespace "com.henninghall.date_picker"
+    }
+
+    if (agpVersion.tokenize('.')[0].toInteger() >= 8) {
+        buildFeatures.buildConfig = true
+    }
 
     sourceSets {
         main {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,7 @@ android {
     }
 
     buildFeatures.buildConfig true
+    namespace 'com.henninghall.date_picker'
 
     sourceSets {
         main {


### PR DESCRIPTION
To build the `android` project with gradle 8+, the added configs are required.

Tested in project with ...
- gradle 8.2
- gradle 7.6