### PR TITLE
fix: Undefined is not a function / NativeModule.closePicker() error using old architecture

### DIFF
--- a/android/src/oldarch/java/com/henninghall/date_picker/DatePickerModule.java
+++ b/android/src/oldarch/java/com/henninghall/date_picker/DatePickerModule.java
@@ -26,8 +26,13 @@ public class DatePickerModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void openPicker(ReadableMap props){
+    public void openPicker(ReadableMap props) {
         module.openPicker(props);
+    }
+    
+    @ReactMethod
+    public void closePicker(){
+        module.closePicker();
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/henninghall/react-native-date-picker/issues/751