### PR TITLE
fix: pin native ios code to tag version

### DIFF
--- a/react-native-date-picker.podspec
+++ b/react-native-date-picker.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.license      = package['license']
   s.platform     = :ios, "8.0"
 
-  s.source       = { :git => "https://github.com/henninghall/react-native-date-picker.git" }
+  s.source       = { :git => "https://github.com/henninghall/react-native-date-picker.git", :tag => "v#{s.version.to_s}" }
   s.source_files    = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency 'React-Core'


### PR DESCRIPTION
without pinning the tag, the latest native files will be fetched by CocoaPods