### PR TITLE
fix: divider color not working on old architecture

### DIFF
--- a/android/src/oldarch/java/com/henninghall/date_picker/DatePickerManager.java
+++ b/android/src/oldarch/java/com/henninghall/date_picker/DatePickerManager.java
@@ -14,6 +14,7 @@ import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactPropGroup;
 import com.henninghall.date_picker.DatePickerModule;
+import com.henninghall.date_picker.props.DividerColorProp;
 import com.henninghall.date_picker.props.Is24hourSourceProp;
 import com.henninghall.date_picker.props.DateProp;
 import com.henninghall.date_picker.props.LocaleProp;
@@ -41,7 +42,7 @@ public class DatePickerManager extends SimpleViewManager<PickerView>  {
 
     @ReactPropGroup(names = { DateProp.name, ModeProp.name, LocaleProp.name, MaximumDateProp.name,
             MinimumDateProp.name, TextColorProp.name, TimezoneOffsetInMinutesProp.name, MinuteIntervalProp.name,
-            Is24hourSourceProp.name
+            Is24hourSourceProp.name, DividerColorProp.name
     })
     public void setProps(PickerView view, int index, Dynamic value) {
         DatePickerManagerImpl.setProps(view, index, value, getClass());


### PR DESCRIPTION
fixes https://github.com/henninghall/react-native-date-picker/issues/787