### PR TITLE
fix: `onStateChange` returns entire event in old arch on some rn versions

### DIFF
--- a/src/DatePickerAndroid.js
+++ b/src/DatePickerAndroid.js
@@ -27,7 +27,13 @@ class DatePickerAndroid extends React.PureComponent {
 
     if (props.modal) return null
 
-    return <NativeComponent {...props} onChange={this._onChange} />
+    return (
+      <NativeComponent
+        {...props}
+        onChange={this._onChange}
+        onStateChange={this._onSpinnerStateChanged}
+      />
+    )
   }
 
   getId = () => {


### PR DESCRIPTION
fixes https://github.com/henninghall/react-native-date-picker/issues/786