### PR TITLE
[android][new_arch][fix]: pass timestamp string instead of iso string…

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0" is_locked="false">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/android/src/main/java/com/henninghall/date_picker/Utils.java
+++ b/android/src/main/java/com/henninghall/date_picker/Utils.java
@@ -32,7 +32,13 @@ public class Utils {
         if(dateString == null) return null;
         try {
             Calendar calendar = Calendar.getInstance(timeZone);
-            calendar.setTime(getIsoUTCFormat().parse(dateString));
+            // Check if the string is a numeric timestamp (positive or negative)
+            if (dateString.matches("-?\\d+")) {  // Matches both positive and negative numbers
+                long timestamp = Long.parseLong(dateString);
+                calendar.setTimeInMillis(timestamp);
+            } else {
+                calendar.setTime(getIsoUTCFormat().parse(dateString));
+            }
             return calendar;
         } catch (ParseException e) {
             e.printStackTrace();

--- a/src/DatePickerAndroid.js
+++ b/src/DatePickerAndroid.js
@@ -96,7 +96,7 @@ const toIsoWithTimeZoneOffset = (date) => {
   /** @ts-ignore */
   if (!date) return undefined
   /** @ts-ignore */
-  return date.toISOString()
+  return date.getTime().toString()
 }
 
 /** @param {string} timestamp */


### PR DESCRIPTION
A workaround for runtime error with new architecture enabled on Android https://github.com/henninghall/react-native-date-picker/issues/840