### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ const getTheme = (props) => {
 const getTextColor = (props) => {
   const darkTheme = getTheme(props) === 'dark'
   if (darkTheme) return 'white'
-  return undefined
+  return 'black'
 }
 
 /** @param {Props} props **/


### PR DESCRIPTION
> return value of getTextColor updated...

- The function named getTextColor in index.js was returning undefined, updated it to 'black'. So that when we have light theme applied, the text color is set to black instead of undefined.

-  Previously, when we have light these the text was not shown because its color are background color were both white. 
-  It must be set to black for white background


> Changes Suggested in following function
```js
const getTextColor = (props) => {
  const darkTheme = getTheme(props) === 'dark'
  if (darkTheme) return 'white'
  return undefined // should be black
}
```

> ### Suggested Change
```diff
- return undefined
+ return 'black'
``` 


