### PR TITLE
fix: Resolve Attribute issue causing Android Build to fail

### DIFF
--- a/android/src/main/java/com/henninghall/date_picker/DatePickerModuleImpl.java
+++ b/android/src/main/java/com/henninghall/date_picker/DatePickerModuleImpl.java
@@ -171,7 +171,7 @@ public class DatePickerModuleImpl {
             coloredTitle.setText(title);
             TypedValue typedValue = new TypedValue();
             Resources.Theme theme = DatePickerPackage.context.getCurrentActivity().getTheme();
-            theme.resolveAttribute(R.attr.dialogPreferredPadding, typedValue, true);
+            theme.resolveAttribute(android.R.attr.dialogPreferredPadding, typedValue, true);
             int paddingInPixels = TypedValue.complexToDimensionPixelSize(typedValue.data, DatePickerPackage.context.getResources().getDisplayMetrics());
             coloredTitle.setPadding(paddingInPixels, paddingInPixels, paddingInPixels, 0);
             coloredTitle.setTextSize(20F);


### PR DESCRIPTION
"Fix resolveAttribute issue in DatePickerModuleImpl.java

Updated the line resolving the 'dialogPreferredPadding' attribute to include the 'android' prefix. This change corrects an error where the attribute could not be found, causing the build to fail on Android. 

Previous:
    theme.resolveAttribute(R.attr.dialogPreferredPadding, typedValue, true);

Updated:
    theme.resolveAttribute(android.R.attr.dialogPreferredPadding, typedValue, true);

This fix ensures that the correct system attribute is referenced, preventing the build failure."