### PR TITLE
Fix default button color on Android when in dark mode, allow buttonColor to take non-hex values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ const DatePickerWrapper = (props) => {
       {...props}
       textColor={colorToHex(getTextColor(props))}
       dividerColor={colorToHex(getDividerColor(props))}
+      buttonColor={colorToHex(getButtonColor(props))}
       theme={getTheme(props)}
       title={getTitle(props)}
       confirmText={props.confirmText ? props.confirmText : 'Confirm'}
@@ -54,6 +55,15 @@ const getDividerColor = (props) => {
 
 /** @param {Props} props **/
 const getTextColor = (props) => {
+  const theme = getTheme(props)
+  if (theme === 'dark') return 'white'
+  if (theme === 'light') return 'black'
+  return undefined
+}
+
+/** @param {Props} props **/
+const getButtonColor = (props) => {
+  if (props.buttonColor) return props.buttonColor
   const theme = getTheme(props)
   if (theme === 'dark') return 'white'
   if (theme === 'light') return 'black'


### PR DESCRIPTION
Currently when passing a theme of 'dark', the title changes to white, but the buttons do not. Also, buttonColor requires a hex value to be passed and not for example the hsl format. This PR changes buttonColor to have the same niceties as e.g. dividerColor, allowing various color formats and changing to white by default when the theme is dark. 