### PR TITLE
feat: Add Android Gradle Plugin namespace support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,9 +12,25 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
+def supportsNamespace() {
+  def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
+  def major = parsed[0].toInteger()
+  def minor = parsed[1].toInteger()
+
+  // Namespace support was added in 7.3.0
+  if (major == 7 && minor >= 3) {
+    return true
+  }
+
+  return major >= 8
+}
+
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 29)
     buildToolsVersion safeExtGet('buildToolsVersion', "25.0.3")
+    if (supportsNamespace()) {
+        namespace "com.henninghall.date_picker"
+    }
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 18)


### PR DESCRIPTION
Adds a version check to conditionally set the namespace for Android builds using Gradle Plugin version 7.3.0 and above.