### PR TITLE
fix ios old architecture expo eas error

### DIFF
--- a/ios/RNDatePickerManager.mm
+++ b/ios/RNDatePickerManager.mm
@@ -51,7 +51,7 @@ RCT_CUSTOM_VIEW_PROPERTY(date, id, DatePicker)
 {
     NSDate *date = [self convertToNSDate:json];
     if (date) {
-        [(DatePicker *)view setDate:date];
+        [view setDate:date];
     }
 }
 
@@ -61,7 +61,7 @@ RCT_CUSTOM_VIEW_PROPERTY(minimumDate, id, DatePicker)
 {
     NSDate *date = [self convertToNSDate:json];
     if (date) {
-        [(DatePicker *)view setMinimumDate:date];
+        [view setMinimumDate:date];
     }
 }
 
@@ -69,7 +69,7 @@ RCT_CUSTOM_VIEW_PROPERTY(maximumDate, id, DatePicker)
 {
     NSDate *date = [self convertToNSDate:json];
     if (date) {
-        [(DatePicker *)view setMaximumDate:date];
+        [view setMaximumDate:date];
     }
 }
 

--- a/ios/RNDatePickerManager.mm
+++ b/ios/RNDatePickerManager.mm
@@ -47,29 +47,29 @@ RCT_EXPORT_METHOD(removeListeners : (NSInteger)count) {
 
 RCT_EXPORT_VIEW_PROPERTY(text, NSString)
 
-RCT_CUSTOM_VIEW_PROPERTY(date, id, RNDatePicker)
+RCT_CUSTOM_VIEW_PROPERTY(date, id, DatePicker)
 {
     NSDate *date = [self convertToNSDate:json];
     if (date) {
-        [(RNDatePicker *)view setDate:date];
+        [(DatePicker *)view setDate:date];
     }
 }
 
 RCT_EXPORT_VIEW_PROPERTY(locale, NSLocale)
 
-RCT_CUSTOM_VIEW_PROPERTY(minimumDate, id, RNDatePicker)
+RCT_CUSTOM_VIEW_PROPERTY(minimumDate, id, DatePicker)
 {
     NSDate *date = [self convertToNSDate:json];
     if (date) {
-        [(RNDatePicker *)view setMinimumDate:date];
+        [(DatePicker *)view setMinimumDate:date];
     }
 }
 
-RCT_CUSTOM_VIEW_PROPERTY(maximumDate, id, RNDatePicker)
+RCT_CUSTOM_VIEW_PROPERTY(maximumDate, id, DatePicker)
 {
     NSDate *date = [self convertToNSDate:json];
     if (date) {
-        [(RNDatePicker *)view setMaximumDate:date];
+        [(DatePicker *)view setMaximumDate:date];
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/henninghall/react-native-date-picker/issues/907

`no visible @interface for 'RNDatePicker'`

