### PR TITLE
fix: added iOS codegen config (fixes iOS DEV crash)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,11 @@
     "jsSrcsDir": "src/fabric",
     "android": {
       "javaPackageName": "com.henninghall.date_picker"
+    },
+    "ios": {
+      "componentProvider": {
+        "RNDatePicker": "RNDatePicker"
+      }
     }
   }
 }


### PR DESCRIPTION
This PR resolves https://github.com/henninghall/react-native-date-picker/issues/919 where the date picker rendering crashes on iOS in dev mode.

@henninghall, could you please check if there are any other implications when adding this?
I'm not experienced with codegen, so I'm unsure if there are side-effects. I just tested this on iOS and it fixes the issue for me.

Credits to @michbil for sharing the solution (thanks again).

All the best,
Laurens