### PR TITLE
fix: add ios.componentProvider and modulesProvider to codegenConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,14 @@
     "jsSrcsDir": "src/fabric",
     "android": {
       "javaPackageName": "com.henninghall.date_picker"
+    },
+    "ios": {
+      "componentProvider": {
+        "RNDatePicker": "RNDatePicker"
+      },
+      "modulesProvider": {
+        "RNDatePicker": "RNDatePickerManager"
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
Fix deprecation warning by adding missing `ios.componentProvider` and `modulesProvider` [configuration](https://reactnative.dev/docs/the-new-architecture/using-codegen#configuring-codegen).

## Problem
When using `react-native-date-picker`, the following deprecation warning appears:

```
[DEPRECATED] react-native-date-picker should add the 'ios.componentProvider' property in their codegenConfig
```

<img width="593" alt="image" src="https://github.com/user-attachments/assets/aee469c9-ca2d-419a-9408-824c8e381d72" />

## Solution
- Added the missing iOS configuration to the `codegenConfig` in `package.json`:

### Added configurations:
- componentProvider: Maps JavaScript RNDatePicker component to iOS RNDatePicker class
- modulesProvider: Maps JavaScript RNDatePicker module to iOS RNDatePickerManager class

## Testing
- environment: expo sdk 53 & react-native v0.79.2
- Verified deprecation warning no longer appears
- UI component continues to work as expected
- Module functions (openPicker, closePicker) work correctly