### PR TITLE
Fix date picker in XCFramework

### DIFF
--- a/ios/RNDatePickerManager.mm
+++ b/ios/RNDatePickerManager.mm
@@ -1,7 +1,7 @@
 #import <React/RCTLog.h>
 #import <React/RCTUIManager.h>
 #import <React/RCTViewManager.h>
-
+#import <React/RCTUtils.h>
 #import "RNDatePickerManager.h"
 #import "RCTConvert.h"
 #import "DatePicker.h"
@@ -94,7 +94,7 @@ RCT_EXPORT_METHOD(openPicker:(NSDictionary *) props
     dispatch_async(dispatch_get_main_queue(), ^{
         
         bool iPad = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad;
-        UIViewController *rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
+        UIViewController *rootViewController = RCTKeyWindow().rootViewController;
         CGRect rootBounds = rootViewController.view.bounds;
         NSString * title = [RCTConvert NSString:[props objectForKey:@"title"]];
         title = [title isEqualToString:@""] ? nil : title;

--- a/ios/RNDatePickerManager.mm
+++ b/ios/RNDatePickerManager.mm
@@ -1,7 +1,8 @@
 #import <React/RCTLog.h>
 #import <React/RCTUIManager.h>
-#import <React/RCTViewManager.h>
 #import <React/RCTUtils.h>
+#import <React/RCTViewManager.h>
+
 #import "RNDatePickerManager.h"
 #import "RCTConvert.h"
 #import "DatePicker.h"


### PR DESCRIPTION
This PR replaces direct access to UIApplication.sharedApplication.delegate.window.rootViewController with RCTKeyWindow().rootViewController.

This change was made to ensure compatibility with modern iOS app architectures (e.g., multi-scene support introduced in iOS 13) and to fix issues when building the module as an xcframework — such as when integrating with Callstack's Enterprise Framework or other brownfield setups.