### PR TITLE
Fix New Architecture support for latest React Native and Expo versions

### DIFF
--- a/ios/RNDatePickerManager.h
+++ b/ios/RNDatePickerManager.h
@@ -8,7 +8,14 @@
 #import <React/RCTConvert.h>
 #import <React/RCTViewManager.h>
 
+#ifdef RCT_NEW_ARCH_ENABLED
+#import "RNDatePickerSpecs.h"
+#endif
+
 @interface RNDatePickerManager : RCTViewManager
+#ifdef RCT_NEW_ARCH_ENABLED
+<NativeRNDatePickerSpec>
+#endif
 
 @property (strong, nonatomic) UIViewController *topViewController;
 

--- a/ios/RNDatePickerManager.mm
+++ b/ios/RNDatePickerManager.mm
@@ -234,6 +234,23 @@ RCT_EXPORT_METHOD(closePicker)
     return 216;
 }
 
+// New Architecture support - provide module instance to TurboModule system
++ (BOOL)requiresMainQueueSetup {
+    return NO;
+}
+
+#ifdef RCT_NEW_ARCH_ENABLED
+// Implement the Spec protocol methods required by TurboModule
+- (void)getConstants:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+    resolve(@{});
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const facebook::react::ObjCTurboModule::InitParams &)params {
+    return std::make_shared<facebook::react::NativeRNDatePickerSpecJSI>(params);
+}
+#endif
+
 @end
+
 
 


### PR DESCRIPTION
## Problem
This package claimed to support React Native's New Architecture from version 4.3.0, but was missing proper TurboModule implementation for the latest React Native and Expo versions with New Architecture enabled by default.

## Solution
- Added proper TurboModule protocol implementation
- Included `RNDatePickerSpecs.h` for New Architecture builds
- Implemented required `getConstants` and `getTurboModule` methods
- Added `requiresMainQueueSetup` method
- Ensured compatibility with both Old and New Architecture using conditional compilation

## Testing
- Tested on React Native 0.79.6 and Expo 53.0.22
- Works with both New and Old Architecture

## Impact
Fixes crashes and compatibility issues for users running latest React Native and Expo versions.