### PR TITLE
fix(new-arch): align TurboModule openPicker signature across iOS, Android, and JS

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Required because pr.yml uses `pull_request_target`, which
+          # otherwise checks out the base branch (master) instead of the
+          # PR head. Without this override, lint runs against master and
+          # PR-side fixes (or breaks) are invisible to the check.
+          # Mirrors the pattern already used in build-android.yml /
+          # build-ios.yml / test-android-*.yml.
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Node
         uses: actions/setup-node@v4

--- a/android/src/newarch/java/com/henninghall/date_picker/DatePickerModule.java
+++ b/android/src/newarch/java/com/henninghall/date_picker/DatePickerModule.java
@@ -2,6 +2,7 @@ package com.henninghall.date_picker;
 
 import androidx.annotation.NonNull;
 
+import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
 
@@ -28,7 +29,13 @@ public class DatePickerModule extends NativeRNDatePickerSpec {
     }
 
     @Override
-    public void openPicker(ReadableMap props){
+    public void openPicker(ReadableMap props, Callback onConfirm, Callback onCancel){
+        // Android delivers confirm/cancel to JS via the RCTDeviceEventEmitter
+        // (see DatePickerModuleImpl), so the callbacks supplied here are
+        // unused. They exist only to keep the TurboModule signature
+        // consistent with the iOS native module, where iOS *does* use the
+        // callbacks. Without them the spec would have to diverge by
+        // platform, which the codegen tooling does not allow.
         module.openPicker(props);
     }
 

--- a/src/DatePickerIOS.js
+++ b/src/DatePickerIOS.js
@@ -23,8 +23,12 @@ export const DatePickerIOS = (props) => {
     style: [styles.datePickerIOS, props.style],
     date: props.date ? props.date.toISOString() : undefined,
     locale: props.locale ? props.locale : undefined,
-    maximumDate: props.maximumDate ? props.maximumDate.toISOString() : undefined,
-    minimumDate: props.minimumDate ? props.minimumDate.toISOString() : undefined,
+    maximumDate: props.maximumDate
+      ? props.maximumDate.toISOString()
+      : undefined,
+    minimumDate: props.minimumDate
+      ? props.minimumDate.toISOString()
+      : undefined,
     theme: props.theme ? props.theme : 'auto',
   }
 

--- a/src/fabric/NativeRNDatePicker.ts
+++ b/src/fabric/NativeRNDatePicker.ts
@@ -5,7 +5,11 @@ import { Double, UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes'
 export interface Spec extends TurboModule {
   readonly getConstants: () => {}
   closePicker(): void
-  openPicker(props: UnsafeObject): void
+  openPicker(
+    props: UnsafeObject,
+    onConfirm: (result: UnsafeObject) => void,
+    onCancel: () => void
+  ): void
   removeListeners(type: Double): void
   addListener(eventName: string): void
 }

--- a/src/modal.js
+++ b/src/modal.js
@@ -76,8 +76,13 @@ export const useModal = ({ props, id }) => {
   useEffect(() => {
     if (shouldOpenModal(props, previousProps)) {
       closing.current = false
+      // The TurboModule spec for `openPicker` declares 3 args because iOS
+      // native uses the callbacks directly. Android routes confirm/cancel
+      // through the `NativeEventEmitter` registered below, so the
+      // callbacks here are no-ops — they exist only to satisfy the
+      // strict arg-count check in the new architecture.
       const params = Platform.select({
-        android: [props],
+        android: [props, () => {}, () => {}],
         ios: [props, onConfirm, onCancel],
       })
       if (!params) throw Error('Unsupported platform')


### PR DESCRIPTION
## Problem

Under React Native's new architecture, the TurboModule runtime enforces strict argument-count parity between the codegen spec, the platform native module, and every JS caller. \`openPicker\` currently disagrees across five places:

| Layer | Args |
|---|---|
| iOS native (\`ios/RNDatePickerManager.mm\`) | **3** (uses callbacks) |
| Android native newarch (\`DatePickerModule\`) | **1** |
| Codegen spec (\`src/fabric/NativeRNDatePicker.ts\`) | **1** |
| JS caller iOS (\`src/modal.js\`) | **3** |
| JS caller Android (\`src/modal.js\`) | **1** |

So one of the two platforms is always wrong:

- With the spec at 1 arg, iOS's 3-arg invocation is over by 2. RN currently permits this, but it is undocumented and fails strict tooling — and the iOS branch wouldn't work at all if RN tightened that check.
- If a consumer patches the spec to **3** args to match iOS native (a common workaround once they hit \`TurboModule method \"openPicker\" called with 1 arguments (expected argument count: 3)\` — see e.g. #883, downstream patches in the wild), Android JS starts crashing on every modal open because its caller still passes 1 arg.

Repro for the consumer case: RN 0.85 + new architecture, Android — open any modal date picker (\`modal\` mode in the component) → strict arg-count crash.

## Fix

Make all five layers agree on **3 args**:

- \`src/fabric/NativeRNDatePicker.ts\` — spec now declares \`openPicker(props, onConfirm, onCancel)\`.
- \`android/src/newarch/java/.../DatePickerModule.java\` — accepts \`Callback onConfirm, Callback onCancel\` and **ignores them**; Android continues to deliver confirm/cancel via the existing \`RCTDeviceEventEmitter\` flow (\`DatePickerModuleImpl\`).
- \`src/modal.js\` — Android branch now passes two no-op callbacks, so the 3-arg signature is honoured on both platforms. iOS branch unchanged.

iOS behaviour is unchanged at runtime (native already takes 3 args and uses them). Android behaviour is unchanged at runtime (the callbacks are unused; events still flow via the emitter listeners registered in \`useModal\`).

## Why this direction (3 args, not 1)

The alternative (move iOS off callbacks onto the emitter pattern so the spec could shrink to 1 arg) is the cleaner long-term refactor — and looks like the direction \`upstream/unify-native-api\` is heading. But that branch is still WIP and a much bigger change. The 3-arg alignment in this PR is the minimum diff that unblocks new-arch consumers today without breaking anything; the deeper unification can land on top later.

## Test plan

- [x] Android new-arch + RN 0.85: \`<DatePicker modal />\` opens and closes, confirm/cancel events still fire
- [x] Android old-arch: builds and runs as before
- [x] iOS new-arch: \`<DatePicker modal />\` opens and closes, confirm/cancel still fire via callbacks
- [x] iOS old-arch: unchanged

Happy to add a test in \`example\` if desired.