### PR TITLE
chore(ci): unblock lint for PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Required because pr.yml uses `pull_request_target`, which
+          # otherwise checks out the base branch (master) instead of the
+          # PR head. Without this override, lint runs against master and
+          # PR-side fixes (or breaks) are invisible to the check.
+          # Mirrors the pattern already used in build-android.yml /
+          # build-ios.yml / test-android-*.yml.
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Node
         uses: actions/setup-node@v4

--- a/src/DatePickerIOS.js
+++ b/src/DatePickerIOS.js
@@ -23,8 +23,12 @@ export const DatePickerIOS = (props) => {
     style: [styles.datePickerIOS, props.style],
     date: props.date ? props.date.toISOString() : undefined,
     locale: props.locale ? props.locale : undefined,
-    maximumDate: props.maximumDate ? props.maximumDate.toISOString() : undefined,
-    minimumDate: props.minimumDate ? props.minimumDate.toISOString() : undefined,
+    maximumDate: props.maximumDate
+      ? props.maximumDate.toISOString()
+      : undefined,
+    minimumDate: props.minimumDate
+      ? props.minimumDate.toISOString()
+      : undefined,
     theme: props.theme ? props.theme : 'auto',
   }
 


### PR DESCRIPTION
## What
Two minimal CI-hygiene fixes that together unblock the lint check on every open PR:

1. **\`src/DatePickerIOS.js\`** — apply \`yarn lint --fix\`. Pre-existing prettier line-wrapping issues at lines 26-27 that have been failing CI on every PR since #894 landed (Feb 2025).
2. **\`.github/workflows/lint.yml\`** — check out the PR head, not master. \`pr.yml\` is triggered by \`pull_request_target\`, which defaults to the base branch for both the workflow file *and* the checkout, so lint was running against master and PR-side fixes were invisible. The other workflows (\`build-android\`, \`build-ios\`, \`test-android-*\`) already use \`ref: \${{ github.event.pull_request.head.sha }}\` — mirroring the same pattern here.

## Why
Every PR right now hits the same wall: lint job reports the prettier issue in master's \`DatePickerIOS.js\`, the PR has no way to fix it (workflow runs against master, not PR), and the PR is blocked. Confirmed by looking at the last ~5 master CI runs — all conclude \`failure\` on the lint job for unrelated reasons.

This PR breaks the chicken-and-egg by applying the trivial 2-line prettier fix on master directly and patching the workflow so future PRs can actually be linted.

## Test plan
- [ ] After merge, re-run lint on any open PR — should now check out the PR head and pass against fixed master.
- [ ] No code behaviour changes — only a line wrap inside a JS object literal.